### PR TITLE
Overload comparison operators for bit vectors

### DIFF
--- a/smt_switch/src/solvers/CVC4Solver.py
+++ b/smt_switch/src/solvers/CVC4Solver.py
@@ -75,6 +75,7 @@ class CVC4Solver(SolverBase):
         self._CVC4InvOps = {self.CVC4.VARIABLE: func_enum.No_op,
                             self.CVC4.CONST_RATIONAL: func_enum.No_op,
                             self.CVC4.CONST_BITVECTOR: func_enum.No_op,
+                            self.CVC4.CONST_BOOLEAN: func_enum.No_op,
                             self.CVC4.BOUND_VARIABLE: func_enum.No_op,
                             # Note: losing info about op of applied function
                             # TODO: see if can extract function definition

--- a/smt_switch/src/terms.py
+++ b/smt_switch/src/terms.py
@@ -61,15 +61,35 @@ class TermBase(metaclass=ABCMeta):
             return self._smt.ApplyFun(self._smt.Sub, zero, self)
 
     def __lt__(self, other):
+        assert not hasattr(other, "sort") or self.sort == other.sort, \
+          "Operator expects 2 arguments of same sort"
+        if self.sort.__class__ == sorts.BitVec:
+            return self._smt.ApplyFun(self._smt.BVSlt, self, other)
+
         return self._smt.ApplyFun(self._smt.LT, self, other)
 
     def __le__(self, other):
+        assert not hasattr(other, "sort") or self.sort == other.sort, \
+          "Operator expects 2 arguments of same sort"
+        if self.sort.__class__ == sorts.BitVec:
+            return self._smt.ApplyFun(self._smt.BVSle, self, other)
+
         return self._smt.ApplyFun(self._smt.LEQ, self, other)
 
     def __gt__(self, other):
+        assert not hasattr(other, "sort") or self.sort == other.sort, \
+          "Operator expects 2 arguments of same sort"
+        if self.sort.__class__ == sorts.BitVec:
+            return self._smt.ApplyFun(self._smt.BVSgt, self, other)
+
         return self._smt.ApplyFun(self._smt.GT, self, other)
 
     def __ge__(self, other):
+        assert not hasattr(other, "sort") or self.sort == other.sort, \
+          "Operator expects 2 arguments of same sort"
+        if self.sort.__class__ == sorts.BitVec:
+            return self._smt.ApplyFun(self._smt.BVSge, self, other)
+
         return self._smt.ApplyFun(self._smt.GEQ, self, other)
 
     # bit operations


### PR DESCRIPTION
Assumed to be signed comparison, use BVU* functions for unsigned comparison

Also added another CVC4 enum for CONST_BOOLEAN