### PR TITLE
Transfer terms

### DIFF
--- a/include/solver.h
+++ b/include/solver.h
@@ -189,6 +189,20 @@ class AbsSmtSolver
   virtual Term substitute(const Term term,
                   const UnorderedTermMap & substitution_map) const;
 
+  /* Transfer a sort from some other solver to this solver
+   *    Warning: does not check if the term already belongs to this solver
+   * @param the sort to transfer
+   * @return the transferred sort
+   */
+  virtual Sort transfer_sort(const Sort sort);
+
+  /* Transfer a term from some other solver to this solver
+   *    Warning: does not check if the term already belongs to this solver
+   * @param the term to transfer
+   * @return the transferred term
+   */
+  virtual Term transfer_term(const Term term);
+
   /* Takes a smt-lib2 value term and creates a Term
    * @param val value term in smt2 format
    * @param sort how to interpret the value (e.g. Real vs Int)

--- a/include/solver.h
+++ b/include/solver.h
@@ -177,6 +177,10 @@ class AbsSmtSolver
   /* Reset all assertions */
   virtual void reset_assertions() = 0;
 
+  // Methods implemented at the abstract level
+  // Note: These can be overloaded in the specific solver implementation for
+  //       performance improvements
+
   /* Substitute all subterms using the provided mapping
    * @param term the term to apply substitution map to
    * @param substitution_map the map to use for substitution
@@ -184,6 +188,12 @@ class AbsSmtSolver
    */
   virtual Term substitute(const Term term,
                   const UnorderedTermMap & substitution_map) const;
+
+  /* Takes a smt-lib2 value term and creates a Term
+   * @param val value term in smt2 format
+   * @param sort how to interpret the value (e.g. Real vs Int)
+   */
+  virtual Term value_from_smt2(const std::string val, const Sort sort) const;
 };
 
 }  // namespace smt

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -49,6 +49,92 @@ Term AbsSmtSolver::substitute(const Term term,
   return cache.at(term);
 }
 
+Sort AbsSmtSolver::transfer_sort(const Sort sort)
+{
+  SortKind sk = sort->get_sort_kind();
+  if ((sk == INT) || (sk == REAL))
+  {
+    return make_sort(sk);
+  }
+  else if (sk == BV)
+  {
+    return make_sort(sk, sort->get_width());
+  }
+  else if (sk == ARRAY)
+  {
+    // recursive call, but it should be okay because we don't expect deep nesting of arrays
+    return make_sort(sk, transfer_sort(sort->get_indexsort()), transfer_sort(sort->get_elemsort()));
+  }
+  else if (sk == FUNCTION)
+  {
+    // recursive call, but it should be okay because we don't expect deep nesting of functions either
+    std::vector<Sort> domain_sorts;
+    for (auto s : sort->get_domain_sorts())
+    {
+      domain_sorts.push_back(transfer_sort(s));
+    }
+    return make_sort(sk, domain_sorts, transfer_sort(sort->get_codomain_sort()));
+  }
+  else
+  {
+    throw SmtException("Failed to transfer sort: " + sort->to_string());
+  }
+}
+
+Term AbsSmtSolver::transfer_term(const Term term)
+{
+  UnorderedTermMap cache;
+  TermVec to_visit { term };
+  TermVec cached_children;
+  Term t;
+  Sort s;
+  while (to_visit.size())
+  {
+    t = to_visit.back();
+    to_visit.pop_back();
+
+    if (cache.find(t) == cache.end())
+    {
+      // doesn't get updated yet, just marking as visited
+      cache[t] = t;
+      to_visit.push_back(t);
+      for (auto c : t)
+      {
+        to_visit.push_back(c);
+      }
+    }
+    else
+    {
+      cached_children.clear();
+      for (auto c : t)
+      {
+        cached_children.push_back(cache.at(c));
+      }
+
+      if (cached_children.size())
+      {
+        cache[t] = make_term(t->get_op(), cached_children);
+      }
+      else if (t->is_symbolic_const())
+      {
+        s = transfer_sort(t->get_sort());
+        cache[t] = make_term(t->to_string(), s);
+      }
+      else if (t->is_value())
+      {
+        s = transfer_sort(t->get_sort());
+        cache[t] = value_from_smt2(t->to_string(), s);
+      }
+      else
+      {
+        throw SmtException("Can't transfer term: " + t->to_string());
+      }
+    }
+  }
+
+  return cache[term];
+}
+
 Term AbsSmtSolver::value_from_smt2(const std::string val, const Sort sort) const
 {
   SortKind sk = sort->get_sort_kind();

--- a/tests/btor/CMakeLists.txt
+++ b/tests/btor/CMakeLists.txt
@@ -5,6 +5,7 @@ set(BTOR_TESTS
   btor-indexed-op-tests
   btor-tests
   btor-incremental
+  btor-transfer
 )
 
 foreach(test ${BTOR_TESTS})

--- a/tests/btor/btor-tests.cpp
+++ b/tests/btor/btor-tests.cpp
@@ -75,6 +75,9 @@ int main()
   s->assert_formula(s->make_term(BVUge, uf_app, s->make_value("00000011", bvsort8, 2)));
   assert(s->check_sat().is_sat());
 
+  assert(s->make_value(4, bvsort8) == s->value_from_smt2("(_ bv4 8)", bvsort8));
+  assert(s->make_value(4, bvsort8) == s->value_from_smt2("#b00000100", bvsort8));
+
   Term xc = s->get_value(x);
   Term yc = s->get_value(y);
   Term zc = s->get_value(z);

--- a/tests/btor/btor-transfer.cpp
+++ b/tests/btor/btor-transfer.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <memory>
+#include <vector>
+#include "assert.h"
+
+#include "boolector_factory.h"
+#include "smt.h"
+// after a full installation
+// #include "smt-switch/boolector_factory.h"
+// #include "smt-switch/smt.h"
+
+using namespace smt;
+using namespace std;
+
+int main()
+{
+  SmtSolver s = BoolectorSolverFactory::create();
+  s->set_logic("QF_ABV");
+  s->set_opt("produce-models", true);
+  Sort bvsort8 = s->make_sort(BV, 8);
+  Term x = s->make_term("x", bvsort8);
+  Term y = s->make_term("y", bvsort8);
+  Term z = s->make_term("z", bvsort8);
+
+  Term constraint = s->make_term(Equal, z, s->make_term(BVAdd, x, y));
+  s->assert_formula(constraint);
+
+  SmtSolver s2 = BoolectorSolverFactory::create();
+  s2->set_logic("QF_ABV");
+  s2->set_opt("produce-models", true);
+  s2->set_opt("incremental", true);
+
+  Term constraint2 = s2->transfer_term(constraint);
+  s2->assert_formula(constraint2);
+
+  cout << "term from solver 1: " << constraint << endl;
+  cout << "term from solver 2: " << constraint2 << endl;
+
+  assert(s->check_sat().is_sat());
+  assert(s2->check_sat().is_sat());
+
+  return 0;
+}

--- a/tests/cvc4/CMakeLists.txt
+++ b/tests/cvc4/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CVC4_TESTS
   cvc4_test
   cvc4-tests
   cvc4-incremental
+  # cvc4-transfer # need to be able to get operator for rebuilding
 )
 
 foreach(test ${CVC4_TESTS})

--- a/tests/cvc4/cvc4-tests.cpp
+++ b/tests/cvc4/cvc4-tests.cpp
@@ -73,6 +73,9 @@ int main()
   s->assert_formula(s->make_term(BVUge, uf_app, s->make_value("00000011", bvsort8, 2)));
   assert(s->check_sat().is_sat());
 
+  assert(s->make_value(4, bvsort8) == s->value_from_smt2("(_ bv4 8)", bvsort8));
+  assert(s->make_value(4, bvsort8) == s->value_from_smt2("#b00000100", bvsort8));
+
   Term xc = s->get_value(x);
   Term yc = s->get_value(y);
   Term zc = s->get_value(z);

--- a/tests/cvc4/cvc4-transfer.cpp
+++ b/tests/cvc4/cvc4-transfer.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <memory>
+#include <vector>
+#include "assert.h"
+
+#include "cvc4_factory.h"
+#include "smt.h"
+// after a full installation
+// #include "smt-switch/cvc4_factory.h"
+// #include "smt-switch/smt.h"
+
+using namespace smt;
+using namespace std;
+
+int main()
+{
+  SmtSolver s = CVC4SolverFactory::create();
+  s->set_opt("produce-models", true);
+  Sort bvsort8 = s->make_sort(BV, 8);
+  Term x = s->make_term("x", bvsort8);
+  Term y = s->make_term("y", bvsort8);
+  Term z = s->make_term("z", bvsort8);
+
+  Term a = s->make_term("a", s->make_sort(INT));
+  Term b = s->make_term("b", s->make_sort(INT));
+
+  Term constraint = s->make_term(Equal, z, s->make_term(BVAdd, x, y));
+  constraint = s->make_term(And, constraint, s->make_term(Lt, a, b));
+  s->assert_formula(constraint);
+
+  SmtSolver s2 = CVC4SolverFactory::create();
+  s2->set_opt("produce-models", true);
+  s2->set_opt("incremental", true);
+
+  Term constraint2 = s2->transfer_term(constraint);
+  s2->assert_formula(constraint2);
+
+  cout << "term from solver 1: " << constraint << endl;
+  cout << "term from solver 2: " << constraint2 << endl;
+
+  assert(s->check_sat().is_sat());
+  assert(s2->check_sat().is_sat());
+
+  return 0;
+}


### PR DESCRIPTION
Add a method at the `smt-switch` solver level to transfer terms from one solver to another (doesn't check if they already belong to that solver yet)