### PR TITLE
Test and fix OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: cpp
-
 sudo: false
-
-# compiler:
-#   - gcc
-#   - clang
 
 addons:
   apt:
@@ -22,32 +17,27 @@ addons:
       - openjdk-8-jdk
       - swig3.0
 
-# env:
-#   - SOLVER="btor"
-#   - SOLVER="cvc4"
-#   - SOLVER="msat"
-
 jobs:
   include:
-    # - os: linux
-    #   dist: bionic
-    #   env: SOLVER="btor"
-    #   compiler: gcc
-    # - os: linux
-    #   dist: bionic
-    #   env: SOLVER="btor"
-    #   compiler: clang
-    # - os: linux
-    #   dist: bionic
-    #   env: SOLVER="cvc4"
-    #   compiler: gcc
-    # - os: linux
-    #   dist: bionic
-    #   env: SOLVER="cvc4"
-    #   compiler: clang
-    # - os: linux
-    #   dist: bionic
-    #   env: SOLVER="msat"
+    - os: linux
+      dist: bionic
+      env: SOLVER="btor"
+      compiler: gcc
+    - os: linux
+      dist: bionic
+      env: SOLVER="btor"
+      compiler: clang
+    - os: linux
+      dist: bionic
+      env: SOLVER="cvc4"
+      compiler: gcc
+    - os: linux
+      dist: bionic
+      env: SOLVER="cvc4"
+      compiler: clang
+    - os: linux
+      dist: bionic
+      env: SOLVER="msat"
     - os: osx
       osx_image: xcode9
       env: SOLVER='btor'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - linux
-    dist: bionic
   - osx
 
 language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
+os:
+  - linux
+    dist: bionic
+  - osx
+
 language: cpp
 
 sudo: false
-dist: bionic
 
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,25 +29,34 @@ addons:
 
 jobs:
   include:
-    - os: linux
-      dist: bionic
-      env: SOLVER="btor"
-      compiler: gcc
-    - os: linux
-      dist: bionic
-      env: SOLVER="btor"
-      compiler: clang
-    - os: linux
-      dist: bionic
-      env: SOLVER="cvc4"
-      compiler: gcc
-    - os: linux
-      dist: bionic
-      env: SOLVER="cvc4"
-      compiler: clang
-    - os: linux
-      dist: bionic
-      env: SOLVER="msat"
+    # - os: linux
+    #   dist: bionic
+    #   env: SOLVER="btor"
+    #   compiler: gcc
+    # - os: linux
+    #   dist: bionic
+    #   env: SOLVER="btor"
+    #   compiler: clang
+    # - os: linux
+    #   dist: bionic
+    #   env: SOLVER="cvc4"
+    #   compiler: gcc
+    # - os: linux
+    #   dist: bionic
+    #   env: SOLVER="cvc4"
+    #   compiler: clang
+    # - os: linux
+    #   dist: bionic
+    #   env: SOLVER="msat"
+    - os: osx
+      osx_image: xcode9
+      env: SOLVER='btor'
+    - os: osx
+      osx_image: xcode9
+      env: SOLVER='cvc4'
+    - os: osx
+      osx_image: xcode9
+      env: SOLVER='msat'
 
 script:
   - bash -c "./contrib/setup-${SOLVER}.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
-os:
-  - linux
-  - osx
-
 language: cpp
 
 sudo: false
 
-compiler:
-  - gcc
-  - clang
+# compiler:
+#   - gcc
+#   - clang
 
 addons:
   apt:
@@ -26,10 +22,32 @@ addons:
       - openjdk-8-jdk
       - swig3.0
 
-env:
-  - SOLVER="btor"
-  - SOLVER="cvc4"
-  - SOLVER="msat"
+# env:
+#   - SOLVER="btor"
+#   - SOLVER="cvc4"
+#   - SOLVER="msat"
+
+jobs:
+  include:
+    - os: linux
+      dist: bionic
+      env: SOLVER="btor"
+      compiler: gcc
+    - os: linux
+      dist: bionic
+      env: SOLVER="btor"
+      compiler: clang
+    - os: linux
+      dist: bionic
+      env: SOLVER="cvc4"
+      compiler: gcc
+    - os: linux
+      dist: bionic
+      env: SOLVER="cvc4"
+      compiler: clang
+    - os: linux
+      dist: bionic
+      env: SOLVER="msat"
 
 script:
   - bash -c "./contrib/setup-${SOLVER}.sh"

--- a/btor/CMakeLists.txt
+++ b/btor/CMakeLists.txt
@@ -4,8 +4,10 @@ add_library(smt-switch-btor "${SMT_SWITCH_LIB_TYPE}"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/boolector_solver.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/boolector_sort.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/boolector_term.cpp"
+  "${PROJECT_SOURCE_DIR}/contrib/memstream-0.1/memstream.c"
   )
 target_include_directories (smt-switch-btor PUBLIC "${PROJECT_SOURCE_DIR}/include")
+target_include_directories (smt-switch-btor PUBLIC "${PROJECT_SOURCE_DIR}/contrib/memstream-0.1/")
 target_include_directories (smt-switch-btor PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_include_directories (smt-switch-btor PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/btor/include")
 target_include_directories (smt-switch-btor PUBLIC "${BTOR_HOME}/src")

--- a/btor/src/boolector_term.cpp
+++ b/btor/src/boolector_term.cpp
@@ -283,10 +283,18 @@ std::string BoolectorTerm::to_string() const
     size_t size;
     FILE * stream = open_memstream(&cres, &size);
     boolector_dump_smt2_node(btor, stream, node);
-    fflush(stream);
+    int status = fflush(stream);
+    if (status != 0)
+    {
+      throw InternalSolverException("Error flushing stream for btor to_string");
+    }
+    status = fclose(stream);
+    if (status != 0)
+    {
+      throw InternalSolverException("Error closing stream for btor to_string");
+    }
     sres = cres;
     free(cres);
-    free(stream);
     return sres;
   }
 }

--- a/btor/src/boolector_term.cpp
+++ b/btor/src/boolector_term.cpp
@@ -2,7 +2,10 @@
 
 // include standard version of open_memstream
 // for compatability with FreeBSD / Darwin which doesn't support it natively
+extern "C"
+{
 #include "memstream.h"
+}
 
 #include <unordered_map>
 #include "stdio.h"

--- a/btor/src/boolector_term.cpp
+++ b/btor/src/boolector_term.cpp
@@ -1,5 +1,9 @@
 #include "boolector_term.h"
 
+// include standard version of open_memstream
+// for compatability with FreeBSD / Darwin which doesn't support it natively
+#include "memstream.h"
+
 #include <unordered_map>
 #include "stdio.h"
 

--- a/contrib/memstream-0.1/Makefile
+++ b/contrib/memstream-0.1/Makefile
@@ -1,0 +1,12 @@
+all : test
+
+test : test.c memstream.o memstream.h
+	cc -Wall -g -o $@ $< memstream.o
+
+memstream.o : memstream.c memstream.h
+	cc -Wall -g -c memstream.c
+
+clean : .FORCE
+	rm -rf *~ *.o test *.dSYM
+
+.FORCE :

--- a/contrib/memstream-0.1/README
+++ b/contrib/memstream-0.1/README
@@ -1,0 +1,3 @@
+Downloaded from: https://www.piumarta.com/software/memstream/
+
+Serves as an open_memstream definition for Free BSD / Darwin systems that don't support it natively

--- a/contrib/memstream-0.1/memstream.c
+++ b/contrib/memstream-0.1/memstream.c
@@ -1,0 +1,177 @@
+/* Compile this file and link the object with your program.  On a recent
+ * GNU/Linux machine the object file will be empty.  On anything derived from
+ * 4.4BSD (Darwin, the Three BSDs, etc.) it will contain an implementation of
+ * open_memstream() as described in the POSIX and Linux manual pages.  On
+ * anything else it will probably cause a compilation error.
+ * 
+ * ----------------------------------------------------------------------------
+ * 
+ * OPEN_MEMSTREAM(3)      BSD and Linux Library Functions     OPEN_MEMSTREAM(3)
+ * 
+ * SYNOPSIS
+ *     #include "memstream.h"
+ * 
+ *     FILE *open_memstream(char **bufp, size_t *sizep);
+ * 
+ * DESCRIPTION
+ *     The open_memstream()  function opens a  stream for writing to  a buffer.
+ *     The   buffer  is   dynamically  allocated   (as  with   malloc(3)),  and
+ *     automatically grows  as required.  After closing the  stream, the caller
+ *     should free(3) this buffer.
+ * 
+ *     When  the  stream is  closed  (fclose(3))  or  flushed (fflush(3)),  the
+ *     locations  pointed  to  by  bufp  and  sizep  are  updated  to  contain,
+ *     respectively,  a pointer  to  the buffer  and  the current  size of  the
+ *     buffer.  These values  remain valid only as long  as the caller performs
+ *     no further output  on the stream.  If further  output is performed, then
+ *     the  stream  must  again  be  flushed  before  trying  to  access  these
+ *     variables.
+ * 
+ *     A null byte  is maintained at the  end of the buffer.  This  byte is not
+ *     included in the size value stored at sizep.
+ * 
+ *     The stream's  file position can  be changed with fseek(3)  or fseeko(3).
+ *     Moving the file position past the  end of the data already written fills
+ *     the intervening space with zeros.
+ * 
+ * RETURN VALUE
+ *     Upon  successful  completion open_memstream()  returns  a FILE  pointer.
+ *     Otherwise, NULL is returned and errno is set to indicate the error.
+ * 
+ * CONFORMING TO
+ *     POSIX.1-2008
+ * 
+ * ----------------------------------------------------------------------------
+ */
+
+#include "memstream.h"
+
+#if _POSIX_C_SOURCE < 200809L
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+
+#define min(X, Y) (((X) < (Y)) ? (X) : (Y))
+
+struct memstream
+{
+    int      position;
+    int      size;
+    int      capacity;
+    char    *contents;
+    char   **ptr;
+    size_t  *sizeloc;
+};
+
+#if MEMSTREAM_DEBUG
+  static void memstream_print(struct memstream *ms)
+  {
+      printf("memstream %p {", ms);
+      printf(" %i", ms->position);
+      printf(" %i", ms->size);
+      printf(" %i", ms->capacity);
+      printf(" %p", ms->contents);
+      printf(" }\n");
+  }
+# define memstream_info(ARGS) printf ARGS
+#else
+# define memstream_print(ms)
+# define memstream_info(ARGS)
+#endif
+
+#define memstream_check(MS) if (!(MS)->contents) { errno= ENOMEM;  return -1; }
+
+static int memstream_grow(struct memstream *ms, int minsize)
+{
+    int newcap= ms->capacity * 2;					memstream_check(ms);
+    while (newcap <= minsize) newcap *= 2;				memstream_info(("grow %p to %i\n", ms, newcap));
+    ms->contents= realloc(ms->contents, newcap);
+    if (!ms->contents) return -1;	/* errno == ENOMEM */
+    memset(ms->contents + ms->capacity, 0, newcap - ms->capacity);
+    ms->capacity= newcap;
+    *ms->ptr= ms->contents;		/* size has not changed */
+    return 0;
+}
+
+static int memstream_read(void *cookie, char *buf, int count)
+{
+    struct memstream *ms= (struct memstream *)cookie;			memstream_check(ms);
+    int n= min(ms->size - ms->position, count);				memstream_info(("memstream_read %p %i\n", ms, count));
+    if (n < 1) return 0;
+    memcpy(buf, ms->contents, n);
+    ms->position += n;							memstream_print(ms);
+    return n;
+}
+
+static int memstream_write(void *cookie, const char *buf, int count)
+{
+    struct memstream *ms= (struct memstream *)cookie;			memstream_check(ms);
+    if (ms->capacity <= ms->position + count)
+	if (memstream_grow(ms, ms->position + count) < 0)		/* errno == ENOMEM */
+	    return -1;
+    memcpy(ms->contents + ms->position, buf, count);			memstream_info(("memstream_write %p %i\n", ms, count));
+    ms->position += count;
+    if (ms->size < ms->position) *ms->sizeloc= ms->size= ms->position;	memstream_print(ms);
+									assert(ms->size < ms->capacity);
+									assert(ms->contents[ms->size] == 0);
+    return count;
+}
+
+static fpos_t memstream_seek(void *cookie, fpos_t offset, int whence)
+{
+    struct memstream *ms= (struct memstream *)cookie;
+    fpos_t pos= 0;							memstream_check(ms);
+									memstream_info(("memstream_seek %p %i %i\n", ms, (int)offset, whence));
+    switch (whence) {
+	case SEEK_SET:	pos= offset;			break;
+	case SEEK_CUR:	pos= ms->position + offset;	break;
+	case SEEK_END:	pos= ms->size + offset;		break;
+	default:	errno= EINVAL;			return -1;
+    }
+    if (pos >= ms->capacity) memstream_grow(ms, pos);
+    ms->position= pos;
+    if (ms->size < ms->position) *ms->sizeloc= ms->size= ms->position;	memstream_print(ms);  memstream_info(("=> %i\n", (int)pos));
+									assert(ms->size < ms->capacity && ms->contents[ms->size] == 0);
+    return pos;
+}
+
+static int memstream_close(void *cookie)
+{
+    struct memstream *ms= (struct memstream *)cookie;			if (!ms->contents) { free(ms);  errno= ENOMEM;  return -1; }
+    ms->size= min(ms->size, ms->position);
+    *ms->ptr= ms->contents;
+    *ms->sizeloc= ms->size;						assert(ms->size < ms->capacity);
+    ms->contents[ms->size]= 0;
+    free(ms);
+    return 0;
+}
+
+FILE *open_memstream(char **ptr, size_t *sizeloc)
+{
+    if (ptr && sizeloc) {
+	struct memstream *ms= calloc(1, sizeof(struct memstream));
+	FILE *fp= 0;							if (!ms) return 0;	/* errno == ENOMEM */
+	ms->position= ms->size= 0;
+	ms->capacity= 4096;
+	ms->contents= calloc(ms->capacity, 1);				if (!ms->contents) { free(ms);  return 0; } /* errno == ENOMEM */
+	ms->ptr= ptr;
+	ms->sizeloc= sizeloc;
+	memstream_print(ms);
+	fp= funopen(ms, memstream_read, memstream_write, memstream_seek, memstream_close);
+	if (!fp) {
+	    free(ms->contents);
+	    free(ms);
+	    return 0;	/* errno set by funopen */
+	}
+	*ptr= ms->contents;
+	*sizeloc= ms->size;
+	return fp;
+    }
+    errno= EINVAL;
+    return 0;
+}
+
+#endif /* _POSIX_C_SOURCE < 200809L */

--- a/contrib/memstream-0.1/memstream.h
+++ b/contrib/memstream-0.1/memstream.h
@@ -1,0 +1,11 @@
+#if defined(__linux__)
+# include <features.h>
+#endif
+
+#include <stdio.h>
+
+#if _POSIX_C_SOURCE < 200809L
+
+FILE *open_memstream(char **ptr, size_t *sizeloc);
+
+#endif /* _POSIX_C_SOURCE < 200809L */

--- a/contrib/memstream-0.1/test.c
+++ b/contrib/memstream-0.1/test.c
@@ -1,0 +1,25 @@
+#include "memstream.h"
+
+#include <stdlib.h>
+#include <assert.h>
+
+int main()
+{
+    char *buffer= 0;
+    size_t size= 0;
+    FILE *fp= open_memstream(&buffer, &size);
+    int i;
+    for (i= 0;  i < 10240;  ++i) {
+	static char c= 42;
+	fflush(fp);			assert(size == i);
+	fwrite(&c, 1, 1, fp);
+    }
+    fclose(fp);				assert(size == 10240);
+    free(buffer);
+    fp= open_memstream(&buffer, &size);
+    fprintf(fp, "This is a test of memstream, from main at %p.\n", main);
+    fclose(fp);
+    fputs(buffer, stdout);
+    free(buffer);
+    return 0;
+}

--- a/contrib/setup-cvc4.sh
+++ b/contrib/setup-cvc4.sh
@@ -16,7 +16,7 @@ if [ ! -d "$DEPS/CVC4" ]; then
     ./contrib/get-antlr-3.4
     CXXFLAGS=-fPIC CFLAGS=-fPIC ./configure.sh --static --no-static-binary
     cd build
-    make
+    make -j4
     cd $DIR
 else
     echo "$DEPS/CVC4 already exists. If you want to rebuild, please remove it manually."

--- a/contrib/setup-cvc4.sh
+++ b/contrib/setup-cvc4.sh
@@ -16,7 +16,7 @@ if [ ! -d "$DEPS/CVC4" ]; then
     ./contrib/get-antlr-3.4
     CXXFLAGS=-fPIC CFLAGS=-fPIC ./configure.sh --static --no-static-binary
     cd build
-    make -j$(nproc)
+    make
     cd $DIR
 else
     echo "$DEPS/CVC4 already exists. If you want to rebuild, please remove it manually."

--- a/tests/cvc4/cvc4-int-arithmetic.cpp
+++ b/tests/cvc4/cvc4-int-arithmetic.cpp
@@ -33,7 +33,7 @@ int main()
   assert(r.is_sat());
 
   cout << "Model Values:" << endl;
-  for (auto t : std::vector{ x, y, z })
+  for (auto t : TermVec({ x, y, z }))
   {
     cout << "\t" << t << " = " << s->get_value(t) << endl;
   }

--- a/tests/msat/msat-int-arithmetic.cpp
+++ b/tests/msat/msat-int-arithmetic.cpp
@@ -33,7 +33,7 @@ int main()
   assert(r.is_sat());
 
   cout << "Model Values:" << endl;
-  for (auto t : std::vector{ x, y, z })
+  for (auto t : TermVec({ x, y, z }))
   {
     cout << "\t" << t << " = " << s->get_value(t) << endl;
   }


### PR DESCRIPTION
Some tests were failing on Mac OSX. This pull request resolves those issues and tests Mac in the Travis builds.

Boolector tests were failing simply because I called `free` on a stream, when `fclose` was sufficient. This was fixed with this be9fa833a1808b6f80273a4501a8eaf7f315fa2e.

CVC4 tests failed on Travis due to some strange `clang posix_spawn` issue on Mac:
```
/bin/sh: fork: Resource temporarily unavailable
make[2]: *** [src/CMakeFiles/cvc4.dir/theory/quantifiers/extended_rewrite.cpp.o] Error 128
make[2]: *** Waiting for unfinished jobs....
[ 50%] Building CXX object src/CMakeFiles/cvc4.dir/theory/quantifiers/fmf/model_engine.cpp.o
[ 50%] Building CXX object src/CMakeFiles/cvc4.dir/theory/quantifiers/fun_def_process.cpp.o
clang: error: unable to execute command: posix_spawn failed: Resource temporarily unavailable
/bin/sh: fork: Resource temporarily unavailable
make[2]: *** [src/CMakeFiles/cvc4.dir/theory/quantifiers/fmf/model_engine.cpp.o] Error 128
```

This was resolved simply by not using `nproc` to set the number of threads for building CVC4, but instead using a constant number (4).

@lstuntz