### PR TITLE
Added Google Test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,27 @@ add_library(smt-switch "${SMT_SWITCH_LIB_TYPE}"
 # build testing infrastructure
 enable_testing()
 
+# Download and unpack googletest at configure time
+configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)
+
 # should we build boolector?
 option (BUILD_BTOR
   "Should we build the libraries for boolector" OFF)

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)


### PR DESCRIPTION
In each solver's CMakeLists.txt, add something like the following to link against gtest or gtest_main as needed:
```
add_executable(example example.cpp)
target_link_libraries(example gtest_main)
add_test(NAME example_test COMMAND example)
```

E.g. for Yices: 
Add file tests/yices2/yices2-gtest.cpp which includes tests like those described in the Google Test documentation. 
Edit tests/yices2/CMakeLists.txt to include the following: 
```
add_executable(yices2-gtest yices2-gtest.cpp)
target_include_directories (yices2-gtest PUBLIC "${PROJECT_SOURCE_DIR}/include")
target_link_libraries(yices2-gtest gtest_main)
target_link_libraries(yices2-gtest smt-switch)
target_link_libraries(yices2-gtest smt-switch-yices2)
add_test(NAME ygt_test COMMAND yices2-gtest)
```