### PR TITLE
Build and upload wheels on tagged release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Python Wheels
 
 # comment this out once in master and tested
 # on:
@@ -35,3 +35,22 @@ jobs:
       with:
         name: py${{ matrix.python-version }} wheel
         path: wheelhouse/
+    - name: Installing Python packages
+      shell: bash
+      run: |
+          sudo pip3 install setuptools
+          sudo pip3 install twine
+    - name: Uploading to PyPi
+      shell: bash
+      run: |
+          echo [distutils]                                  > ~/.pypirc
+          echo index-servers =                             >> ~/.pypirc
+          echo "  pypi"                                    >> ~/.pypirc
+          echo                                             >> ~/.pypirc
+          echo [pypi]                                      >> ~/.pypirc
+          echo repository=https://upload.pypi.org/legacy/  >> ~/.pypirc
+          echo username=keyi                               >> ~/.pypirc
+          echo password=$PYPI_PASSWORD                     >> ~/.pypirc
+          twine upload --config-file ~/.pypirc --skip-existing wheelhouse/*
+      env:
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,37 @@
+name: Docker
+
+# comment this out once in master and tested
+# on:
+#   push:
+#     tags:
+#     - '*'
+
+on: [push]
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [35, 36, 37, 38]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+    - name: Build wheels
+      shell: bash
+      run: |
+          docker run --mount type=bind,source="$(pwd)"/../smt-switch,target=/smt-switch keyiz/manylinux-java:py${{ matrix.python-version }} /smt-switch/contrib/wheels/ci.sh
+      env:
+        PY_VERSION: ${{ matrix.python-version }}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: py${{ matrix.python-version }} wheel
+        path: wheelhouse/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,12 +1,9 @@
 name: Python Wheels
 
-# comment this out once in master and tested
-# on:
-#   push:
-#     tags:
-#     - '*'
-
-on: [push]
+on:
+  push:
+    tags:
+      - '*'
 
 
 jobs:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,7 +46,7 @@ jobs:
           echo                                             >> ~/.pypirc
           echo [pypi]                                      >> ~/.pypirc
           echo repository=https://upload.pypi.org/legacy/  >> ~/.pypirc
-          echo username=keyi                               >> ~/.pypirc
+          echo username=makaim                             >> ~/.pypirc
           echo password=$PYPI_PASSWORD                     >> ~/.pypirc
           twine upload --config-file ~/.pypirc --skip-existing wheelhouse/*
       env:

--- a/contrib/wheels/ci.sh
+++ b/contrib/wheels/ci.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+cd smt-switch/
+mkdir -p build
+pip install Cython==0.29 --install-option="--no-cython-compile"
+python contrib/wheels/build_wheel.py bdist_wheel
+auditwheel show dist/*
+auditwheel repair dist/*

--- a/contrib/wheels/ci.sh
+++ b/contrib/wheels/ci.sh
@@ -3,7 +3,7 @@ set -e
 
 cd smt-switch/
 mkdir -p build
-pip install Cython==0.29 --install-option="--no-cython-compile"
+pip install Cython==0.29
 python contrib/wheels/build_wheel.py bdist_wheel
 auditwheel show dist/*
 auditwheel repair dist/*


### PR DESCRIPTION
This PR uses Github Actions to build and deploy wheels to PyPI. It will only trigger the build if it is a tagged. You can see the test package here: https://pypi.org/project/smt-switch/

To test out, simply do
```
pip3 install smt-swittch
```
On any linux machine. It supports Python 3.5+.

@makaimann:
For now it uses my PyPI credential as part of GitHub secrets. I can change the user name to your PyPI account. Once this gets merged, you need to put your PyPI password in as a secret in Github project settings.

I will also either delete the PyPI package or transfer the ownership to you.

EDIT:
I don't have any physical access to OSX, but I've built wheels using CI before. I will submit a PR later that build wheels on OSX platform. If you're interested, I had some luck with Windows wheels via AppVeyor, so I can try that out as well.