### PR TITLE
remove const from assert_formula

### DIFF
--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -43,7 +43,7 @@ class BoolectorSolver : public AbsSmtSolver
   };
   void set_opt(const std::string option, const std::string value) override;
   void set_logic(const std::string logic) override;
-  void assert_formula(const Term & t) const override;
+  void assert_formula(const Term & t) override;
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
   void push(uint64_t num = 1) override;

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -196,7 +196,7 @@ Term BoolectorSolver::make_term(const Term & val, const Sort & sort) const
   }
 }
 
-void BoolectorSolver::assert_formula(const Term & t) const
+void BoolectorSolver::assert_formula(const Term & t)
 {
   std::shared_ptr<BoolectorTerm> bt =
       std::static_pointer_cast<BoolectorTerm>(t);

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -35,7 +35,7 @@ class CVC4Solver : public AbsSmtSolver
   ~CVC4Solver() { };
   void set_opt(const std::string option, const std::string value) override;
   void set_logic(const std::string logic) override;
-  void assert_formula(const Term & t) const override;
+  void assert_formula(const Term & t) override;
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
   void push(uint64_t num = 1) override;

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -204,7 +204,7 @@ Term CVC4Solver::make_term(const Term & val, const Sort & sort) const
   return Term(new CVC4Term(const_arr));
 }
 
-void CVC4Solver::assert_formula(const Term& t) const
+void CVC4Solver::assert_formula(const Term& t)
 {
   try
   {

--- a/include/solver.h
+++ b/include/solver.h
@@ -35,7 +35,7 @@ class AbsSmtSolver
   /* Add an assertion to the solver
    * @param t a boolean term to assert
    */
-  virtual void assert_formula(const Term& t) const = 0;
+  virtual void assert_formula(const Term& t) = 0;
 
   /* Check satisfiability of the current assertions
    * @return a result object - see result.h

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -51,7 +51,7 @@ class MsatSolver : public AbsSmtSolver
   }
   void set_opt(const std::string option, const std::string value) override;
   void set_logic(const std::string log) override;
-  void assert_formula(const Term & t) const override;
+  void assert_formula(const Term & t) override;
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
   void push(uint64_t num = 1) override;
@@ -118,7 +118,7 @@ class MsatInterpolatingSolver : public MsatSolver
     valid_model = false;
   }
   void set_opt(const std::string option, const std::string value) override;
-  void assert_formula(const Term & t) const override;
+  void assert_formula(const Term & t) override;
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
   Term get_value(Term & t) const override;

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -144,7 +144,7 @@ void MsatSolver::set_logic(const std::string log)
   logic = log;
 }
 
-void MsatSolver::assert_formula(const Term & t) const
+void MsatSolver::assert_formula(const Term & t)
 {
   shared_ptr<MsatTerm> mterm = static_pointer_cast<MsatTerm>(t);
   if (msat_assert_formula(env, mterm->term))
@@ -907,7 +907,7 @@ void MsatInterpolatingSolver::set_opt(const string option, const string value)
   throw IncorrectUsageException("Can't set options of interpolating solver.");
 }
 
-void MsatInterpolatingSolver::assert_formula(const Term & t) const
+void MsatInterpolatingSolver::assert_formula(const Term & t)
 {
   throw IncorrectUsageException(
       "Can't assert formulas in interpolating solver");

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -45,7 +45,7 @@ class Yices2Solver : public AbsSmtSolver
   };
   void set_opt(const std::string option, const std::string value) override;
   void set_logic(const std::string logic) override;
-  void assert_formula(const Term & t) const override;
+  void assert_formula(const Term & t) override;
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
   void push(uint64_t num = 1) override;

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -224,7 +224,7 @@ Term Yices2Solver::make_term(const Term & val, const Sort & sort) const
       "Constant arrays not supported for Yices2 backend.");
 }
 
-void Yices2Solver::assert_formula(const Term & t) const
+void Yices2Solver::assert_formula(const Term & t)
 {
   shared_ptr<Yices2Term> yterm = static_pointer_cast<Yices2Term>(t);
 


### PR DESCRIPTION
I want to maintain the list of assertions in a solver that is based on smt-switch. This PR removes const from assert_formula to achieve that.