### PR TITLE
Add unsat core support

### DIFF
--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -23,7 +23,7 @@ class BoolectorSolver : public AbsSmtSolver
 {
  public:
   // might have to use std::unique_ptr<Btor>(boolector_new) and move it?
-  BoolectorSolver() : btor(boolector_new()), produce_unsat_cores(false)
+  BoolectorSolver() : btor(boolector_new())
   {
     // set termination function -- throw an exception
     auto throw_exception = [](const char * msg) -> void {
@@ -94,15 +94,6 @@ class BoolectorSolver : public AbsSmtSolver
   std::unordered_set<std::string> symbol_names;
   // store array bases -- temporary until there are updates to boolector
   std::unordered_map<uint64_t, BoolectorNode *> array_bases;
-  // set to true if producing unsat cores -- need to use assumptions instead of
-  // assertions
-  bool produce_unsat_cores;
-  // if producing unsat cores need to use assumptions
-  // assumptions are removed after each call to boolector_sat
-  // but in smt-switch we want to treat them as assertions
-  // this vector keeps a context-dependent list of assumptions
-  // to be added before each call to check_sat/check_sat_assuming
-  std::vector<std::vector<BoolectorNode *>> unsat_core_assumptions;
 };
 }  // namespace smt
 

--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -23,7 +23,7 @@ class BoolectorSolver : public AbsSmtSolver
 {
  public:
   // might have to use std::unique_ptr<Btor>(boolector_new) and move it?
-  BoolectorSolver() : btor(boolector_new())
+  BoolectorSolver() : btor(boolector_new()), produce_unsat_cores(false)
   {
     // set termination function -- throw an exception
     auto throw_exception = [](const char * msg) -> void {
@@ -49,6 +49,7 @@ class BoolectorSolver : public AbsSmtSolver
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   Term get_value(Term & t) const override;
+  TermVec get_unsat_core() override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;
@@ -93,6 +94,15 @@ class BoolectorSolver : public AbsSmtSolver
   std::unordered_set<std::string> symbol_names;
   // store array bases -- temporary until there are updates to boolector
   std::unordered_map<uint64_t, BoolectorNode *> array_bases;
+  // set to true if producing unsat cores -- need to use assumptions instead of
+  // assertions
+  bool produce_unsat_cores;
+  // if producing unsat cores need to use assumptions
+  // assumptions are removed after each call to boolector_sat
+  // but in smt-switch we want to treat them as assertions
+  // this vector keeps a context-dependent list of assumptions
+  // to be added before each call to check_sat/check_sat_assuming
+  std::vector<std::vector<BoolectorNode *>> unsat_core_assumptions;
 };
 }  // namespace smt
 

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -366,12 +366,11 @@ TermVec BoolectorSolver::get_unsat_core()
 {
   TermVec core;
   BoolectorNode ** bcore = boolector_get_failed_assumptions(btor);
-  BoolectorNode ** bcore_iter = bcore;
-  while (*bcore_iter)
+  while (*bcore)
   {
     core.push_back(std::make_shared<BoolectorTerm>(
-        btor, boolector_copy(btor, *bcore_iter)));
-    bcore_iter++;
+        btor, boolector_copy(btor, *bcore)));
+    ++bcore;
   }
   return core;
 }

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -88,10 +88,13 @@ void BoolectorSolver::set_opt(const std::string option, const std::string value)
   }
   else if (option == "produce-unsat-cores")
   {
-    produce_unsat_cores = true;
-    unsat_core_assumptions.push_back(std::vector<BoolectorNode *>());
-    // needs to be incremental
-    boolector_set_opt(btor, BTOR_OPT_INCREMENTAL, 1);
+    if (value == "true")
+    {
+      produce_unsat_cores = true;
+      unsat_core_assumptions.push_back(std::vector<BoolectorNode *>());
+      // needs to be incremental
+      boolector_set_opt(btor, BTOR_OPT_INCREMENTAL, 1);
+    }
   }
   else
   {

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -213,6 +213,7 @@ void BoolectorSolver::assert_formula(const Term & t)
   if (produce_unsat_cores)
   {
     // unsat core production needs to use assumptions
+    // store the assertion at the current context level
     unsat_core_assumptions[unsat_core_assumptions.size() - 1].push_back(
         bt->node);
   }

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -413,16 +413,13 @@ Term BoolectorSolver::get_value(Term & t) const
 TermVec BoolectorSolver::get_unsat_core()
 {
   TermVec core;
-  for (auto assumptions : unsat_core_assumptions)
+  BoolectorNode ** bcore = boolector_get_failed_assumptions(btor);
+  BoolectorNode ** bcore_iter = bcore;
+  while (*bcore_iter)
   {
-    for (auto a : assumptions)
-    {
-      if (boolector_failed(btor, a))
-      {
-        core.push_back(
-            std::make_shared<BoolectorTerm>(btor, boolector_copy(btor, a)));
-      }
-    }
+    core.push_back(std::make_shared<BoolectorTerm>(
+        btor, boolector_copy(btor, *bcore_iter)));
+    bcore_iter++;
   }
   return core;
 }

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -41,6 +41,7 @@ class CVC4Solver : public AbsSmtSolver
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   Term get_value(Term & t) const override;
+  TermVec get_unsat_core() override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -89,7 +89,16 @@ void CVC4Solver::set_opt(const std::string option, const std::string value)
 {
   try
   {
-    solver.setOption(option, value);
+    if (option == "produce-unsat-cores")
+    {
+      // to be consistent with the smt-switch API, we actually use
+      // produce-unsat-assumptions
+      solver.setOption("produce-unsat-assumptions", value);
+    }
+    else
+    {
+      solver.setOption(option, value);
+    }
   }
   catch (::CVC4::api::CVC4ApiException & e)
   {
@@ -343,12 +352,13 @@ TermVec CVC4Solver::get_unsat_core()
   Term f;
   try
   {
-    for (auto cterm : solver.getUnsatCore())
+    for (auto cterm : solver.getUnsatAssumptions())
     {
       core.push_back(std::make_shared<CVC4Term>(cterm));
     }
   }
-  catch (::CVC4::api::CVC4ApiException & e)
+  // this function seems to return a different exception type
+  catch (std::exception & e)
   {
     throw InternalSolverException(e.what());
   }

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -337,6 +337,24 @@ Term CVC4Solver::get_value(Term & t) const
   }
 }
 
+TermVec CVC4Solver::get_unsat_core()
+{
+  TermVec core;
+  Term f;
+  try
+  {
+    for (auto cterm : solver.getUnsatCore())
+    {
+      core.push_back(std::make_shared<CVC4Term>(cterm));
+    }
+  }
+  catch (::CVC4::api::CVC4ApiException & e)
+  {
+    throw InternalSolverException(e.what());
+  }
+  return core;
+}
+
 Sort CVC4Solver::make_sort(const std::string name, uint64_t arity) const
 {
   try

--- a/include/solver.h
+++ b/include/solver.h
@@ -43,6 +43,7 @@ class AbsSmtSolver
   virtual Result check_sat() = 0;
 
   /* Check satisfiability of the current assertions under the given assumptions
+   * Note: the assumptions must be boolean literals, not arbitrary formulas
    * @param assumptions a vector of boolean literals
    * @return a result object - see result.h
    */
@@ -64,9 +65,10 @@ class AbsSmtSolver
    */
   virtual Term get_value(Term& t) const = 0;
 
-  /** Get a vector of formulas that are sufficient to make the
-   *  assertions unsatisfiable
-   *  @return a vector of terms in the unsat core
+  /** After a call to check_sat_assuming that returns an unsatisfiable result
+   *  this function will return a subset of the assumption literals
+   *  that are sufficient to make the assertions unsat.
+   *  @return a vector of assumption literals in the unsat core
    */
   virtual TermVec get_unsat_core() = 0;
 

--- a/include/solver.h
+++ b/include/solver.h
@@ -64,6 +64,12 @@ class AbsSmtSolver
    */
   virtual Term get_value(Term& t) const = 0;
 
+  /** Get a vector of formulas that are sufficient to make the
+   *  assertions unsatisfiable
+   *  @return a vector of terms in the unsat core
+   */
+  virtual TermVec get_unsat_core() = 0;
+
   // virtual bool check_sat_assuming() const = 0;
 
   /* Make an uninterpreted sort

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -100,7 +100,7 @@ class MsatSolver : public AbsSmtSolver
   // use assumptions if producing unsat cores
   bool produce_unsat_cores;
   // need to solve with assumptions to get unsat core
-  std::vector<msat_term> assumptions;
+  std::vector<msat_term> unsat_core_assumptions;
   std::unordered_map<size_t, msat_term> assump2term;
   // maps context levels to the size of the assumptions vector
   // popping a context means reverting to the previous size

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -57,6 +57,7 @@ class MsatSolver : public AbsSmtSolver
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   Term get_value(Term & t) const override;
+  TermVec get_unsat_core() override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -30,7 +30,7 @@ class MsatSolver : public AbsSmtSolver
   // but in mathsat factory, MUST setup_env
   // this is done after constructing because need to call
   // the virtual function -- e.g. simulating dynamic binding
-  MsatSolver() : logic(""){};
+  MsatSolver() : logic(""), produce_unsat_cores(false), context(0){};
   MsatSolver(const MsatSolver &) = delete;
   MsatSolver & operator=(const MsatSolver &) = delete;
   ~MsatSolver()
@@ -97,6 +97,18 @@ class MsatSolver : public AbsSmtSolver
   msat_env env;
   bool valid_model;
   std::string logic;
+  // use assumptions if producing unsat cores
+  bool produce_unsat_cores;
+  // need to solve with assumptions to get unsat core
+  std::vector<msat_term> assumptions;
+  std::unordered_map<size_t, msat_term> assump2term;
+  // maps context levels to the size of the assumptions vector
+  // popping a context means reverting to the previous size
+  std::unordered_map<int64_t, size_t> context2assumpsize;
+  int64_t context;
+
+  // helper function for creating labels for assumptions
+  msat_term label(msat_term p) const;
 };
 
 // Interpolating Solver

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -46,7 +46,6 @@ class MsatSolver : public AbsSmtSolver
   {
     cfg = msat_create_config();
     msat_set_option(cfg, "model_generation", "true");
-    msat_set_option(cfg, "unsat_core_generation", "1");
     env = msat_create_env(cfg);
     valid_model = false;
   }

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -30,7 +30,7 @@ class MsatSolver : public AbsSmtSolver
   // but in mathsat factory, MUST setup_env
   // this is done after constructing because need to call
   // the virtual function -- e.g. simulating dynamic binding
-  MsatSolver() : logic(""), produce_unsat_cores(false), context(0){};
+  MsatSolver() : logic(""){};
   MsatSolver(const MsatSolver &) = delete;
   MsatSolver & operator=(const MsatSolver &) = delete;
   ~MsatSolver()
@@ -97,15 +97,6 @@ class MsatSolver : public AbsSmtSolver
   msat_env env;
   bool valid_model;
   std::string logic;
-  // use assumptions if producing unsat cores
-  bool produce_unsat_cores;
-  // need to solve with assumptions to get unsat core
-  std::vector<msat_term> unsat_core_assumptions;
-  std::unordered_map<size_t, msat_term> assump2term;
-  // maps context levels to the size of the assumptions vector
-  // popping a context means reverting to the previous size
-  std::unordered_map<int64_t, size_t> context2assumpsize;
-  int64_t context;
 
   // helper function for creating labels for assumptions
   msat_term label(msat_term p) const;

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -46,6 +46,7 @@ class MsatSolver : public AbsSmtSolver
   {
     cfg = msat_create_config();
     msat_set_option(cfg, "model_generation", "true");
+    msat_set_option(cfg, "unsat_core_generation", "1");
     env = msat_create_env(cfg);
     valid_model = false;
   }

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -280,7 +280,7 @@ TermVec MsatSolver::get_unsat_core()
   for (size_t i = 0; i < core_size; ++i)
   {
     core.push_back(std::make_shared<MsatTerm>(env, *mcore_iter));
-    mcore_iter++;
+    ++mcore_iter;
   }
   msat_free(mcore);
   return core;

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -938,7 +938,7 @@ void MsatSolver::dump_smt2(std::string filename) const
 msat_term MsatSolver::label(msat_term p) const
 {
   std::ostringstream buf;
-  buf << ".ref_axiom_lbl{" << msat_term_id(p) << "}";
+  buf << ".assump_lbl{" << msat_term_id(p) << "}";
   std::string name = buf.str();
   msat_decl d =
       msat_declare_function(env, name.c_str(), msat_get_bool_type(env));

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -127,6 +127,16 @@ void MsatSolver::set_opt(const string option, const string value)
                 << std::endl;
     }
   }
+  else if (option == "produce-unsat-cores")
+  {
+    if (value == "false")
+    {
+      std::cout
+          << "Warning: MathSAT backend always produces unsat cores -- it can't "
+             "be disabled."
+          << std::endl;
+    }
+  }
   else
   {
     string msg("Option ");
@@ -250,6 +260,25 @@ Term MsatSolver::get_value(Term & t) const
   }
 
   return Term(new MsatTerm(env, val));
+}
+
+TermVec MsatSolver::get_unsat_core()
+{
+  TermVec core;
+  size_t core_size;
+  msat_term * mcore = msat_get_unsat_core(env, &core_size);
+  if (!mcore)
+  {
+    throw InternalSolverException("Got error term from msat unsat core");
+  }
+  msat_term * mcore_iter = mcore;
+  for (size_t i = 0; i < core_size; ++i)
+  {
+    core.push_back(std::make_shared<MsatTerm>(env, *mcore_iter));
+    mcore_iter++;
+  }
+  msat_free(mcore);
+  return core;
 }
 
 Sort MsatSolver::make_sort(const std::string name, uint64_t arity) const

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -130,7 +130,10 @@ void MsatSolver::set_opt(const string option, const string value)
   }
   else if (option == "produce-unsat-cores")
   {
-    produce_unsat_cores = true;
+    if (value == "true")
+    {
+      produce_unsat_cores = true;
+    }
   }
   else
   {

--- a/python/smt_switch_dec.pxi
+++ b/python/smt_switch_dec.pxi
@@ -98,6 +98,7 @@ cdef extern from "solver.h" namespace "smt":
         void push(uint64_t num) except +
         void pop(uint64_t num) except +
         c_Term get_value(c_Term& t) except +
+        c_TermVec get_unsat_core() except +
         c_Sort make_sort(const string name, uint64_t arity) except +
         c_Sort make_sort(const c_SortKind sk) except +
         c_Sort make_sort(const c_SortKind sk, uint64_t size) except +

--- a/python/smt_switch_imp.pxi
+++ b/python/smt_switch_imp.pxi
@@ -267,6 +267,14 @@ cdef class SmtSolver:
         term.ct = dref(self.css).get_value(t.ct)
         return term
 
+    def get_unsat_core(self):
+        unsat_core = []
+        for l in dref(self.css).get_unsat_core():
+            term = Term(self)
+            term.ct = l
+            unsat_core.append(term)
+        return unsat_core
+
     def make_sort(self, arg0, arg1=None, arg2=None, arg3=None):
         cdef Sort s = Sort(self)
         cdef c_SortKind sk

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,11 @@ target_link_libraries(test-int gtest_main)
 target_link_libraries(test-int available-solvers)
 add_test(NAME test-int_test COMMAND test-int)
 
+add_executable(test-unsat-core "${PROJECT_SOURCE_DIR}/tests/test-unsat-core.cpp")
+target_link_libraries(test-unsat-core gtest_main)
+target_link_libraries(test-unsat-core available-solvers)
+add_test(NAME test-unsat-core_test COMMAND test-unsat-core)
+
 add_executable(unit-transfer "${PROJECT_SOURCE_DIR}/tests/unit/unit-transfer.cpp")
 target_link_libraries(unit-transfer gtest_main)
 target_link_libraries(unit-transfer available-solvers)

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -133,10 +133,7 @@ std::vector<SolverEnum> available_unsat_core_solver_enums()
   std::vector<SolverEnum> solvers;
   for (auto se : solver_enums)
   {
-    if (se != YICES2)
-    {
-      solvers.push_back(se);
-    }
+    solvers.push_back(se);
   }
   return solvers;
 }

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -128,6 +128,19 @@ std::vector<SolverEnum> available_full_transfer_solver_enums()
   return solvers;
 }
 
+std::vector<SolverEnum> available_unsat_core_solver_enums()
+{
+  std::vector<SolverEnum> solvers;
+  for (auto se : solver_enums)
+  {
+    if (se != BTOR && se != MSAT && se != YICES2)
+    {
+      solvers.push_back(se);
+    }
+  }
+  return solvers;
+}
+
 std::ostream & operator<<(std::ostream & o, SolverEnum e)
 {
   switch (e)

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -133,7 +133,7 @@ std::vector<SolverEnum> available_unsat_core_solver_enums()
   std::vector<SolverEnum> solvers;
   for (auto se : solver_enums)
   {
-    if (se != BTOR && se != MSAT && se != YICES2)
+    if (se != BTOR && se != YICES2)
     {
       solvers.push_back(se);
     }

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -133,7 +133,7 @@ std::vector<SolverEnum> available_unsat_core_solver_enums()
   std::vector<SolverEnum> solvers;
   for (auto se : solver_enums)
   {
-    if (se != BTOR && se != YICES2)
+    if (se != YICES2)
     {
       solvers.push_back(se);
     }

--- a/tests/available_solvers.h
+++ b/tests/available_solvers.h
@@ -39,6 +39,8 @@ std::vector<SolverEnum> available_constarr_solver_enums();
 
 std::vector<SolverEnum> available_full_transfer_solver_enums();
 
+std::vector<SolverEnum> available_unsat_core_solver_enums();
+
 std::ostream & operator<<(std::ostream & o, SolverEnum e);
 
 }  // namespace smt_tests

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -46,6 +46,24 @@ TEST_P(UnsatCoreTests, UnsatCore)
   ASSERT_TRUE(core.size() > 1);
 }
 
+TEST_P(UnsatCoreTests, UnsatCoreCheckSatAssuming)
+{
+  Term a = s->make_symbol("a", boolsort);
+  Term b = s->make_symbol("b", boolsort);
+  s->assert_formula(a);
+  s->assert_formula(b);
+  Result r = s->check_sat_assuming({s->make_term(Not, b)});
+  ASSERT_TRUE(r.is_unsat());
+
+  TermVec core = s->get_unsat_core();
+  ASSERT_TRUE(core.size() > 1);
+
+  // for solvers using assumptions under the hood,
+  // make sure they are re-added correctly
+  r = s->check_sat();
+  ASSERT_TRUE(r.is_sat());
+}
+
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnsatCoreTests,
                          UnsatCoreTests,
                          testing::ValuesIn(available_unsat_core_solver_enums()));

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -1,0 +1,53 @@
+#include <utility>
+#include <vector>
+
+#include "available_solvers.h"
+#include "gtest/gtest.h"
+#include "smt.h"
+
+using namespace smt;
+using namespace std;
+
+namespace smt_tests {
+
+class UnsatCoreTests : public ::testing::Test,
+                 public ::testing::WithParamInterface<SolverEnum>
+{
+ protected:
+  void SetUp() override
+  {
+    s = available_solvers().at(GetParam())();
+    s->set_opt("incremental", "true");
+    s->set_opt("produce-unsat-cores", "true");
+    boolsort = s->make_sort(BOOL);
+  }
+  SmtSolver s;
+  Sort boolsort;
+};
+
+TEST_P(UnsatCoreTests, UnsatCore)
+{
+  Term a = s->make_symbol("a", boolsort);
+  Term b = s->make_symbol("b", boolsort);
+  s->assert_formula(a);
+  s->assert_formula(b);
+  s->assert_formula(s->make_term(Not, b));
+  Result r = s->check_sat();
+  ASSERT_TRUE(r.is_unsat());
+
+  TermVec core = s->get_unsat_core();
+  ASSERT_TRUE(core.size() > 1);
+
+  // for solvers using assumptions under the hood,
+  // make sure they are re-added correctly
+  r = s->check_sat();
+  ASSERT_TRUE(r.is_unsat());
+  core = s->get_unsat_core();
+  ASSERT_TRUE(core.size() > 1);
+}
+
+INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnsatCoreTests,
+                         UnsatCoreTests,
+                         testing::ValuesIn(available_unsat_core_solver_enums()));
+
+}  // namespace smt_tests

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -29,30 +29,7 @@ TEST_P(UnsatCoreTests, UnsatCore)
 {
   Term a = s->make_symbol("a", boolsort);
   Term b = s->make_symbol("b", boolsort);
-  s->assert_formula(a);
-  s->assert_formula(b);
-  s->assert_formula(s->make_term(Not, b));
-  Result r = s->check_sat();
-  ASSERT_TRUE(r.is_unsat());
-
-  TermVec core = s->get_unsat_core();
-  ASSERT_TRUE(core.size() > 1);
-
-  // for solvers using assumptions under the hood,
-  // make sure they are re-added correctly
-  r = s->check_sat();
-  ASSERT_TRUE(r.is_unsat());
-  core = s->get_unsat_core();
-  ASSERT_TRUE(core.size() > 1);
-}
-
-TEST_P(UnsatCoreTests, UnsatCoreCheckSatAssuming)
-{
-  Term a = s->make_symbol("a", boolsort);
-  Term b = s->make_symbol("b", boolsort);
-  s->assert_formula(a);
-  s->assert_formula(b);
-  Result r = s->check_sat_assuming({s->make_term(Not, b)});
+  Result r = s->check_sat_assuming({ a, b, s->make_term(Not, b) });
   ASSERT_TRUE(r.is_unsat());
 
   TermVec core = s->get_unsat_core();
@@ -62,6 +39,7 @@ TEST_P(UnsatCoreTests, UnsatCoreCheckSatAssuming)
   // make sure they are re-added correctly
   r = s->check_sat();
   ASSERT_TRUE(r.is_sat());
+  ASSERT_THROW(core = s->get_unsat_core(), SmtException);
 }
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnsatCoreTests,

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -25,7 +25,7 @@ namespace smt {
 class Yices2Solver : public AbsSmtSolver
 {
  public:
-  Yices2Solver() : produce_unsat_cores(false), assumps_context(0)
+  Yices2Solver()
   {
     // Had to move yices_init to the Factory
     // yices_init();
@@ -88,16 +88,6 @@ class Yices2Solver : public AbsSmtSolver
  protected:
   mutable context_t * ctx;
   mutable ctx_config_t * config;
-  // for unsat cores, need to always use assumptions instead of assertions
-  // requires some extra tracking
-  bool produce_unsat_cores;
-  std::vector<term_t> unsat_core_assumptions;
-  // maps context to the size of the assumptions array
-  // popping just resizes the array
-  std::unordered_map<int, size_t> context2assumpsize;
-  // keeps track of context for assumptions (only used when producing unsat
-  // cores)
-  int assumps_context;
 };
 }  // namespace smt
 

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -25,7 +25,7 @@ namespace smt {
 class Yices2Solver : public AbsSmtSolver
 {
  public:
-  Yices2Solver()
+  Yices2Solver() : produce_unsat_cores(false), assumps_context(0)
   {
     // Had to move yices_init to the Factory
     // yices_init();
@@ -88,6 +88,16 @@ class Yices2Solver : public AbsSmtSolver
  protected:
   mutable context_t * ctx;
   mutable ctx_config_t * config;
+  // for unsat cores, need to always use assumptions instead of assertions
+  // requires some extra tracking
+  bool produce_unsat_cores;
+  std::vector<term_t> unsat_core_assumptions;
+  // maps context to the size of the assumptions array
+  // popping just resizes the array
+  std::unordered_map<int, size_t> context2assumpsize;
+  // keeps track of context for assumptions (only used when producing unsat
+  // cores)
+  int assumps_context;
 };
 }  // namespace smt
 

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -51,6 +51,7 @@ class Yices2Solver : public AbsSmtSolver
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   Term get_value(Term & t) const override;
+  TermVec get_unsat_core() override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -388,9 +388,24 @@ TermVec Yices2Solver::get_unsat_core()
         "Last call to check_sat was not unsat, cannot get unsat core.");
   }
 
+  if(!v)
+  {
+    throw InternalSolverException("Got an uninitialized vector");
+  }
+
   TermVec core;
+
+  if (!v->size)
+  {
+    throw InternalSolverException("Core is empty");
+  }
+
   for (size_t i = 0; i < v->size; ++i)
   {
+    if (!v->data[i])
+    {
+      throw InternalSolverException("Got an empty term from vector");
+    }
     core.push_back(std::make_shared<Yices2Term>(v->data[i]));
   }
 

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -379,37 +379,26 @@ Term Yices2Solver::get_value(Term & t) const
 
 TermVec Yices2Solver::get_unsat_core()
 {
-  term_vector_t * v;
-  yices_init_term_vector(v);
-  int32_t err_code = yices_get_unsat_core(ctx, v);
+  term_vector_t ycore;
+  yices_init_term_vector(&ycore);
+  int32_t err_code = yices_get_unsat_core(ctx, &ycore);
   if (err_code == CTX_INVALID_OPERATION)
   {
     throw IncorrectUsageException(
         "Last call to check_sat was not unsat, cannot get unsat core.");
   }
 
-  if(!v)
-  {
-    throw InternalSolverException("Got an uninitialized vector");
-  }
-
   TermVec core;
-
-  if (!v->size)
+  for (size_t i = 0; i < ycore.size; ++i)
   {
-    throw InternalSolverException("Core is empty");
-  }
-
-  for (size_t i = 0; i < v->size; ++i)
-  {
-    if (!v->data[i])
+    if (!ycore.data[i])
     {
       throw InternalSolverException("Got an empty term from vector");
     }
-    core.push_back(std::make_shared<Yices2Term>(v->data[i]));
+    core.push_back(std::make_shared<Yices2Term>(ycore.data[i]));
   }
 
-  yices_delete_term_vector(v);
+  yices_delete_term_vector(&ycore);
 
   return core;
 }

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -273,7 +273,7 @@ Result Yices2Solver::check_sat()
 
 Result Yices2Solver::check_sat_assuming(const TermVec & assumptions)
 {
-  // TODO: possible check this in another way
+  // TODO: possibly check this in another way
   // for now, yices2 should throw an error for us
   // // expecting (possibly negated) boolean literals
   // for (auto a : assumptions)

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -338,6 +338,11 @@ Term Yices2Solver::get_value(Term & t) const
   }
 }
 
+TermVec Yices2Solver::get_unsat_core()
+{
+  throw NotImplementedException("Yices2 backend does not implement get_unsat_core yet");
+}
+
 Sort Yices2Solver::make_sort(const std::string name, uint64_t arity) const
 {
   type_t y_sort;


### PR DESCRIPTION
Adds support for querying backend solvers for unsat cores. After some discussion, we decided the interface should use `check_sat_assuming`. Thus, after a call to `check_sat_assuming`, `get_unsat_core` will return a vector with a subset of the assumptions that are sufficient to make the assertions unsat.