### PR TITLE
Adding SMT-LIB descriptions of API functions in solver.h

### DIFF
--- a/include/solver.h
+++ b/include/solver.h
@@ -38,55 +38,64 @@ class AbsSmtSolver
   virtual ~AbsSmtSolver(){};
 
   /* Sets a solver option with smt-lib 2 syntax
+   * SMTLIB: (set-option :<option> <value>)
    * @param option name of the option
    * @param value string value
    */
   virtual void set_opt(const std::string option, const std::string value) = 0;
 
   /* Sets a solver logic -- see smt-lib 2 logics
+   * SMTLIB: (set-logic <logic>)
    * @param logic name of logic
    */
   virtual void set_logic(const std::string logic) = 0;
 
   /* Add an assertion to the solver
+   * SMTLIB: (assert <t>)
    * @param t a boolean term to assert
    */
   virtual void assert_formula(const Term & t) = 0;
 
   /* Check satisfiability of the current assertions
+   * SMTLIB: (check-sat)
    * @return a result object - see result.h
    */
   virtual Result check_sat() = 0;
 
   /* Check satisfiability of the current assertions under the given assumptions
    * Note: the assumptions must be boolean literals, not arbitrary formulas
+   * SMTLIB: (check-sat-assuming (t1 t2 ... tn)) with asssumptions = [t1,...,tn]
    * @param assumptions a vector of boolean literals
    * @return a result object - see result.h
    */
   virtual Result check_sat_assuming(const TermVec & assumptions) = 0;
 
   /* Push contexts
+   * SMTLIB: (push <num>)
    * @param num the number of contexts to push
    */
   virtual void push(uint64_t num = 1) = 0;
 
   /* Pop contexts
+   * SMTLIB: (pop <num>)
    * @param num the number of contexts to pop
    */
   virtual void pop(uint64_t num = 1) = 0;
 
   /* Get the value of a term after check_sat returns a satisfiable result
+   * SMTLIB: (get-value (<t>))
    * @param t the term to get the value of
    * @return a value term
    */
   virtual Term get_value(const Term & t) const = 0;
 
-  /** Get a map of index-value pairs for an array term after check_sat returns
+  /* Get a map of index-value pairs for an array term after check_sat returns
    * sat
-   *  @param arr the array to get the value for
-   *  @param out_const_base a term that will be updated to the const base of the
+   * SMTLIB: (get-value (<t>))
+   * @param arr the array to get the value for
+   * @param out_const_base a term that will be updated to the const base of the
    * array if there is one. Otherwise, it will be assigned null
-   *  @return a map of index value pairs for the array
+   * @return a map of index value pairs for the array
    */
   virtual UnorderedTermMap get_array_values(const Term & arr,
                                             Term & out_const_base) const = 0;
@@ -94,6 +103,7 @@ class AbsSmtSolver
   /** After a call to check_sat_assuming that returns an unsatisfiable result
    *  this function will return a subset of the assumption literals
    *  that are sufficient to make the assertions unsat.
+   *  SMTLIB: (get-unsat-assumptions)
    *  @return a vector of assumption literals in the unsat core
    */
   virtual TermVec get_unsat_core() = 0;
@@ -101,6 +111,7 @@ class AbsSmtSolver
   // virtual bool check_sat_assuming() const = 0;
 
   /* Make an uninterpreted sort
+   * SMTLIB: (declare-sort <name> <arity>)
    * @param name the name of the sort
    * @param arity the arity of the sort
    * @return a Sort object
@@ -197,6 +208,7 @@ class AbsSmtSolver
   virtual Term make_term(const Term & val, const Sort & sort) const = 0;
 
   /* Make a symbolic constant or function term
+   * SMTLIB: (declare-fun <name> (s1 ... sn) s) where sort = s1x...xsn -> s
    * @param name the name of constant or function
    * @param sort the sort of this constant or function
    * @return the symbolic constant or function term
@@ -241,10 +253,13 @@ class AbsSmtSolver
 
   /* Return the solver to it's startup state
    * WARNING: This destroys all created terms and sorts
+   * SMTLIB: (reset)
    */
   virtual void reset() = 0;
 
-  /* Reset all assertions */
+  /* Reset all assertions 
+   * SMTLIB: (reset-assertions)
+   */
   virtual void reset_assertions() = 0;
 
 


### PR DESCRIPTION
This PR adds the equivalent SMT-LIB command for each API function in solver.h (where applicable).