### PR TITLE
Expose solver enums through smt-switch API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,9 @@ add_library(smt-switch "${SMT_SWITCH_LIB_TYPE}"
   "${PROJECT_SOURCE_DIR}/src/logging_term.cpp"
   "${PROJECT_SOURCE_DIR}/src/logging_sort_computation.cpp"
   "${PROJECT_SOURCE_DIR}/src/logging_solver.cpp"
-  "${PROJECT_SOURCE_DIR}/src/utils.cpp")
+  "${PROJECT_SOURCE_DIR}/src/utils.cpp"
+  "${PROJECT_SOURCE_DIR}/src/available_solvers.cpp"
+  )
 
 # Should we build python bindings
 option (BUILD_PYTHON_BINDINGS
@@ -65,6 +67,12 @@ if (BUILD_BTOR)
   if (NOT DEFINED BTOR_HOME)
     set(BTOR_HOME "${PROJECT_SOURCE_DIR}/deps/boolector")
   endif()
+
+  # Define C macros for available_solvers
+  # and tests parameterized by solver
+  add_definitions(-DBUILD_BTOR)
+  add_definitions(-DBTOR_HOME=${BTOR_HOME})
+
   add_subdirectory (btor)
   set (SOLVER_BACKEND_LIBS ${SOLVER_BACKEND_LIBS} smt-switch-btor)
 
@@ -80,6 +88,12 @@ if (BUILD_CVC4)
   if (NOT DEFINED CVC4_HOME)
     set(CVC4_HOME "${PROJECT_SOURCE_DIR}/deps/CVC4")
   endif()
+
+  # Define C macros for available_solvers
+  # and tests parameterized by solver
+  add_definitions(-DBUILD_CVC4)
+  add_definitions(-DCVC4_HOME=${CVC4_HOME})
+
   add_subdirectory (cvc4)
   set (SOLVER_BACKEND_LIBS ${SOLVER_BACKEND_LIBS} smt-switch-cvc4)
 
@@ -95,6 +109,12 @@ if (BUILD_MSAT)
   if (NOT DEFINED MSAT_HOME)
     set(MSAT_HOME "${PROJECT_SOURCE_DIR}/deps/mathsat")
   endif()
+
+  # Define C macros for available_solvers
+  # and tests parameterized by solver
+  add_definitions(-DBUILD_MSAT)
+  add_definitions(-DMSAT_HOME=${MSAT_HOME})
+
   add_subdirectory (msat)
   set (SOLVER_BACKEND_LIBS ${SOLVER_BACKEND_LIBS} smt-switch-msat)
 
@@ -111,6 +131,12 @@ if (BUILD_YICES2)
   if (NOT DEFINED YICES2_HOME)
     set(YICES2_HOME "${PROJECT_SOURCE_DIR}/deps/yices2")
   endif()
+
+  # Define C macros for available_solvers
+  # and tests parameterized by solver
+  add_definitions(-DBUILD_YICES2)
+  add_definitions(-DYICES2_HOME=${YICES2_HOME})
+
   add_subdirectory (yices2)
   set (SOLVER_BACKEND_LIBS ${SOLVER_BACKEND_LIBS} smt-switch-yices2)
 

--- a/include/available_solvers.h
+++ b/include/available_solvers.h
@@ -101,13 +101,13 @@ struct hash<smt_tests::SolverEnum>
 };
 
 // specialize template
- template <>
-   struct hash<smt_tests::SolverAttribute>
- {
-   size_t operator()(const smt_tests::SolverAttribute sa) const
-   {
-     return static_cast<size_t>(sa);
-   }
- };
+template <>
+struct hash<smt_tests::SolverAttribute>
+{
+  size_t operator()(const smt_tests::SolverAttribute sa) const
+  {
+    return static_cast<size_t>(sa);
+  }
+};
 
 }  // namespace std

--- a/src/available_solvers.cpp
+++ b/src/available_solvers.cpp
@@ -68,14 +68,16 @@ const std::unordered_map<SolverEnum, std::unordered_set<SolverAttribute>>
             UNSAT_CORE } },
 
         { CVC4,
-          { TERMITER,
-            THEORY_INT,
-            // TODO: put this back after getStoreAllBase() is in API
-            // ARRAY_MODELS,
-            CONSTARR,
-            FULL_TRANSFER,
-            UNSAT_CORE,
-            THEORY_DATATYPE, } },
+          {
+              TERMITER,
+              THEORY_INT,
+              // TODO: put this back after getStoreAllBase() is in API
+              // ARRAY_MODELS,
+              CONSTARR,
+              FULL_TRANSFER,
+              UNSAT_CORE,
+              THEORY_DATATYPE,
+          } },
 
         { CVC4_LOGGING,
           { LOGGING,
@@ -199,9 +201,9 @@ SmtSolver create_interpolating_solver(SolverEnum se)
 
 const std::vector<SolverEnum> itp_enums({
 #if BUILD_MSAT
-                                         MSAT
+  MSAT
 #endif
-  });
+});
 
 std::vector<SolverEnum> available_solver_enums() { return solver_enums; }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,28 +24,7 @@ add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
                  ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
                  EXCLUDE_FROM_ALL)
 
-
-# Define C macros for available_solvers
-# used in the parametrized tests so that it knows which
-# solvers to run with
-if (BUILD_BTOR)
-  add_definitions(-DBUILD_BTOR)
-endif(BUILD_BTOR)
-
-if (BUILD_CVC4)
-  add_definitions(-DBUILD_CVC4)
-endif(BUILD_CVC4)
-
-if (BUILD_MSAT)
-  add_definitions(-DBUILD_MSAT)
-endif(BUILD_MSAT)
-
-if (BUILD_YICES2)
-  add_definitions(-DBUILD_YICES2)
-endif(BUILD_YICES2)
-
 add_library(test-deps "${SMT_SWITCH_LIB_TYPE}"
-  "${PROJECT_SOURCE_DIR}/tests/available_solvers.cpp"
   "${PROJECT_SOURCE_DIR}/tests/test-utils.cpp"
   )
 


### PR DESCRIPTION
Tag every solver with an enum so we can identify the backend solver that is used by an SmtSolver pointer. It also provides some utility functions for SolverEnums.

Note: there is not an easy way to expose available_solvers through the API (i.e. outside of the testing infrastructure). This is because the interface is meant to be completely solver-agnostic. Thus, you could build smt-switch once with all the solvers, but only link solvers as you need them. So, there's no reliable way to tell which solvers are available, because it depends on which libraries have been linked to your program. If it becomes a desired feature, maybe there is a way to register available classes based on linked libraries...I'm not sure.