### PR TITLE
Printing solver interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(smt-switch "${SMT_SWITCH_LIB_TYPE}"
   "${PROJECT_SOURCE_DIR}/src/logging_term.cpp"
   "${PROJECT_SOURCE_DIR}/src/logging_sort_computation.cpp"
   "${PROJECT_SOURCE_DIR}/src/logging_solver.cpp"
+  "${PROJECT_SOURCE_DIR}/src/printing_solver.cpp"
   "${PROJECT_SOURCE_DIR}/src/utils.cpp")
 
 # Should we build python bindings

--- a/include/printing_solver.h
+++ b/include/printing_solver.h
@@ -49,6 +49,7 @@ class PrintingSolver : public AbsSmtSolver
 
   /* Operators that are printed */
   Sort make_sort(const std::string name, uint64_t arity) const override;
+  Term make_symbol(const std::string name, const Sort & sort) override;
 
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
@@ -69,7 +70,7 @@ class PrintingSolver : public AbsSmtSolver
 
 
   /* Operators that are not printed 
-   * For example, creating terms is not printted, but the
+   * For example, creating terms is not printed, but the
    * created terms will appear in other commands (e.g., assert). 
    * */
   Sort make_sort(const SortKind sk) const override;
@@ -99,7 +100,6 @@ class PrintingSolver : public AbsSmtSolver
                  const Sort & sort,
                  uint64_t base = 10) const override;
   Term make_term(const Term & val, const Sort & sort) const override;
-  Term make_symbol(const std::string name, const Sort & sort) override;
   Term make_term(const Op op, const Term & t) const override;
   Term make_term(const Op op, const Term & t0, const Term & t1) const override;
   Term make_term(const Op op,

--- a/include/printing_solver.h
+++ b/include/printing_solver.h
@@ -1,0 +1,106 @@
+/*********************                                                        */
+/*! \file printing_solver.h
+** \verbatim
+** Top contributors (to current version):
+**   Yoni Zohar
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Class that wraps another SmtSolver and tracks the term DAG by
+**        wrapping sorts and terms and performs hash-consing.
+**
+**/
+
+#pragma once
+
+#include "solver.h"
+#include "term_hashtable.h"
+
+namespace smt {
+
+enum PrintingStyleEnum
+{
+  DEFAULT = 0,
+  BTOR,
+  CVC4,
+  MSAT,
+  YICES2
+};
+
+class PrintingSolver : public AbsSmtSolver
+{
+ public:
+  PrintingSolver(SmtSolver s, std::ostream*, PrintingStyleEnum pse); 
+  ~PrintingSolver();
+
+  // implemented
+  Sort make_sort(const std::string name, uint64_t arity) const override;
+  Sort make_sort(const SortKind sk) const override;
+  Sort make_sort(const SortKind sk, uint64_t size) const override;
+  Sort make_sort(const SortKind sk, const Sort & sort1) const override;
+  Sort make_sort(const SortKind sk,
+                 const Sort & sort1,
+                 const Sort & sort2) const override;
+  Sort make_sort(const SortKind sk,
+                 const Sort & sort1,
+                 const Sort & sort2,
+                 const Sort & sort3) const override;
+  Sort make_sort(const SortKind sk, const SortVec & sorts) const override;
+  Sort make_sort(const DatatypeDecl & d) const override;
+
+  DatatypeDecl make_datatype_decl(const std::string & s) override;
+  DatatypeConstructorDecl make_datatype_constructor_decl(const std::string s) const override;
+  void add_constructor(DatatypeDecl & dt, const DatatypeConstructorDecl & con) const override;
+  void add_selector(DatatypeConstructorDecl & dt, const std::string & name, const Sort & s) const override;
+  void add_selector_self(DatatypeConstructorDecl & dt, const std::string & name) const override;
+  Term get_constructor(const Sort & s, std::string name) const override;
+  Term get_tester(const Sort & s, std::string name) const override;
+  Term get_selector(const Sort & s, std::string con, std::string name) const override;
+
+  Term make_term(bool b) const override;
+  Term make_term(int64_t i, const Sort & sort) const override;
+  Term make_term(const std::string val,
+                 const Sort & sort,
+                 uint64_t base = 10) const override;
+  Term make_term(const Term & val, const Sort & sort) const override;
+  Term make_symbol(const std::string name, const Sort & sort) override;
+  Term make_term(const Op op, const Term & t) const override;
+  Term make_term(const Op op, const Term & t0, const Term & t1) const override;
+  Term make_term(const Op op,
+                 const Term & t0,
+                 const Term & t1,
+                 const Term & t2) const override;
+  Term make_term(const Op op, const TermVec & terms) const override;
+  Term get_value(const Term & t) const override;
+  UnorderedTermMap get_array_values(const Term & arr,
+                                    Term & out_const_base) const override;
+  TermVec get_unsat_core() override;
+  // Will probably remove this eventually
+  // For now, need to clear the hash table
+  void reset() override;
+
+  // dispatched to underlying solver
+  void set_opt(const std::string option, const std::string value) override;
+  void set_logic(const std::string logic) override;
+  void assert_formula(const Term & t) override;
+  Result check_sat() override;
+  Result check_sat_assuming(const TermVec & assumptions) override;
+  void push(uint64_t num = 1) override;
+  void pop(uint64_t num = 1) override;
+  void reset_assertions() override;
+  bool get_interpolant(const Term & A,
+                               const Term & B,
+                               Term & out_I) const override;
+
+ protected:
+  SmtSolver wrapped_solver;  ///< the underlying solver
+  std::ostream* out_stream;
+  PrintingStyleEnum style;
+};
+
+SmtSolver create_printing_solver(SmtSolver wrapped_solver, std::ostream* out_stream, PrintingStyleEnum style);
+
+}  // namespace smt

--- a/src/printing_solver.cpp
+++ b/src/printing_solver.cpp
@@ -1,0 +1,45 @@
+/*********************                                                        */
+/*! \file printing_solver.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Yoni Zohar
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Class that wraps another SmtSolver and tracks the term DAG by
+**        wrapping sorts and terms and performs hash-consing.
+**
+**/
+
+#include "printing_solver.h"
+#include "utils.h"
+
+
+#define SET_OPTION_STR "set-option"
+#define SET_LOGIC_STR "set-logic"
+#define DECLARE_FUN_STR "declare-fun"
+#define DECLARE_SORT_STR "declare-sort"
+#define ASSERT_STR "assert"
+#define CHECK_SAT_STR "check-sat"
+#define CHECK_SAT_ASSUMING_STR "check-sat-assuming"
+#define GET_VALUE_STR "get-value"
+#define GET_UNSAT_ASSUMPTIONS_STR "get-unsat-assumptions"
+#define PUSH_STR "push"
+#define POP_STR "pop"
+#define RESET_ASSERTIONS_STR "reset-assertions"
+#define RESET_STR "reset"
+#define INTERPOLATION_GROUP_STR "interpolation-group"
+#define MSAT_GET_INTERPOLANT_STR "get-interpolant"
+
+using namespace std;
+
+namespace smt {
+
+/* PrintingSolver */
+
+// implementations
+
+}  // namespace smt

--- a/src/printing_solver.cpp
+++ b/src/printing_solver.cpp
@@ -9,15 +9,14 @@
 ** All rights reserved.  See the file LICENSE in the top-level source
 ** directory for licensing information.\endverbatim
 **
-** \brief Class that wraps another SmtSolver and tracks the term DAG by
-**        wrapping sorts and terms and performs hash-consing.
-**
+** \brief Class that wraps another SmtSolver and dumps SMT-LIB
+**        that corresponds to the operations being performed.
 **/
 
 #include "printing_solver.h"
 #include "utils.h"
 
-
+/* string macros for the SMT-LIB commands */
 #define SET_OPTION_STR "set-option"
 #define SET_LOGIC_STR "set-logic"
 #define DECLARE_FUN_STR "declare-fun"


### PR DESCRIPTION
This PR adds the interface to create and use a "printing solver", that is, a solver that dumps each SMT-LIB command it performs to a stream.
The current PR only adds the .h file, an almost empty cpp file, and the required change to cmake. It also includes documentation.
A subsequent PR will add all implementations and tests.