### PR TITLE
Add option to support reset_assertions in btor backend with contexts

### DIFF
--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -118,6 +118,14 @@ class BoolectorSolver : public AbsSmtSolver
   Btor * btor;
   // store the names of created symbols
   std::unordered_set<std::string> symbol_names;
+
+  bool base_context_1 = false;
+  ///< if set to true, do all solving at context 1 in the solver
+  ///< this then supports reset_assertions by popping and re-pushing
+  ///< the context. Without it, boolector does not support
+  ///< reset_assertions yet
+  ///< set this flag with set_opt("base-context-1", "true")
+  size_t context_level = 0;  ///< tracks the current solving context level
 };
 }  // namespace smt
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,7 +97,6 @@ target_link_libraries(test-dt gtest_main)
 target_link_libraries(test-dt test-deps)
 add_test(NAME test-dt_test COMMAND test-dt)
 
-
 add_executable(test-array "${PROJECT_SOURCE_DIR}/tests/test-array.cpp")
 target_link_libraries(test-array gtest_main)
 target_link_libraries(test-array test-deps)
@@ -127,3 +126,8 @@ add_executable(unit-arrays "${PROJECT_SOURCE_DIR}/tests/unit/unit-arrays.cpp")
 target_link_libraries(unit-arrays gtest_main)
 target_link_libraries(unit-arrays test-deps)
 add_test(NAME unit-arrays_test COMMAND unit-arrays)
+
+add_executable(unit-reset-assertions "${PROJECT_SOURCE_DIR}/tests/unit/unit-reset-assertions.cpp")
+target_link_libraries(unit-reset-assertions gtest_main)
+target_link_libraries(unit-reset-assertions test-deps)
+add_test(NAME unit-reset-assertions_test COMMAND unit-reset-assertions)

--- a/tests/unit/unit-op.cpp
+++ b/tests/unit/unit-op.cpp
@@ -27,7 +27,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitTests : public ::testing::Test,
-                  public testing::WithParamInterface<SolverEnum>
+                  public ::testing::WithParamInterface<SolverEnum>
 {
  protected:
   void SetUp() override

--- a/tests/unit/unit-reset-assertions.cpp
+++ b/tests/unit/unit-reset-assertions.cpp
@@ -95,6 +95,8 @@ TEST_P(UnitResetAssertionsTests, ResetAssertions)
   ASSERT_TRUE(r.is_sat());
 }
 
+// only run this test if built with Boolector
+#ifdef BUILD_BTOR
 TEST(UnitBtorResetAssertionsTests, ResetAssertionsException)
 {
   // Boolector backend does not support reset_assertions by default
@@ -114,6 +116,7 @@ TEST(UnitBtorResetAssertionsTests, ResetAssertionsException)
 
   ASSERT_THROW(s->reset_assertions(), NotImplementedException);
 }
+#endif
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnitResetAssertions,
                          UnitResetAssertionsTests,

--- a/tests/unit/unit-reset-assertions.cpp
+++ b/tests/unit/unit-reset-assertions.cpp
@@ -1,0 +1,122 @@
+/*********************                                                        */
+/*! \file unit-reset-assertions.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Unit tests for resetting assertions
+**        Note: there's a special case for Boolector
+**        Boolector does not currently support reset_assertions natively. But,
+**        it can be approximated by doing all solving at context level 1, and
+**        popping all the contexts to reset assertions.
+**
+**
+**/
+
+#include <utility>
+#include <vector>
+
+#include "available_solvers.h"
+#include "gtest/gtest.h"
+#include "smt.h"
+
+using namespace smt;
+using namespace std;
+
+namespace smt_tests {
+
+class UnitResetAssertionsTests
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<SolverEnum>
+{
+ protected:
+  void SetUp() override
+  {
+    SolverEnum se = GetParam();
+    s = create_solver(se);
+    s->set_opt("produce-models", "true");
+    s->set_opt("incremental", "true");
+
+    if (se == BTOR || se == BTOR_LOGGING)
+    {
+      // special option for boolector
+      // not enabled by default because it can affect performance
+      s->set_opt("base-context-1", "true");
+    }
+
+    bvsort = s->make_sort(BV, 8);
+  }
+  SmtSolver s;
+  Sort bvsort;
+};
+
+TEST_P(UnitResetAssertionsTests, ResetAssertions)
+{
+  Term x = s->make_symbol("x", bvsort);
+  Term y = s->make_symbol("y", bvsort);
+  Term xpy = s->make_term(BVAdd, x, y);
+  Term xmy = s->make_term(BVSub, x, y);
+
+  Term constraint = s->make_term(Equal, xpy, xmy);
+  s->assert_formula(constraint);
+
+  Result r = s->check_sat();
+  assert(r.is_sat());
+
+  Term zero = s->make_term(0, bvsort);
+  Term make_unsat = s->make_term(
+      And, s->make_term(Distinct, x, zero), s->make_term(Distinct, y, zero));
+  Term half_max = s->make_term(128, bvsort);
+  make_unsat = s->make_term(And,
+                            make_unsat,
+                            s->make_term(And,
+                                         s->make_term(BVUlt, x, half_max),
+                                         s->make_term(BVUlt, y, half_max)));
+  s->push(2);
+  s->assert_formula(make_unsat);
+  r = s->check_sat();
+  ASSERT_TRUE(r.is_unsat());
+  s->pop(2);
+
+  r = s->check_sat();
+  ASSERT_TRUE(r.is_sat());
+
+  s->assert_formula(make_unsat);
+  r = s->check_sat();
+  ASSERT_TRUE(r.is_unsat());
+
+  s->reset_assertions();
+  r = s->check_sat();
+  ASSERT_TRUE(r.is_sat());
+}
+
+TEST(UnitBtorResetAssertionsTests, ResetAssertionsException)
+{
+  // Boolector backend does not support reset_assertions by default
+  // Underlying solver boolector does not have reset_assertions
+  // but we can approximate it using solving contexts, but this
+  // might impact performance
+  SmtSolver s = create_solver(BTOR);
+  s->set_opt("produce-models", "true");
+  s->set_opt("incremental", "true");
+  Sort bvsort = s->make_sort(BV, 8);
+
+  Term f = s->make_term(false);
+  s->assert_formula(f);
+
+  Result r = s->check_sat();
+  ASSERT_TRUE(r.is_unsat());
+
+  ASSERT_THROW(s->reset_assertions(), NotImplementedException);
+}
+
+INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnitResetAssertions,
+                         UnitResetAssertionsTests,
+                         testing::ValuesIn(available_solver_enums()));
+
+}  // namespace smt_tests


### PR DESCRIPTION
Boolector does not support reset_assertions. We can approximate it at the Smt-switch level by always solving at context 1 and popping back to context 0 to reset assertions (then pushing to context 1 again before continuing).

I decided to have this option disabled by default because it likely impacts performance. But, the exception that is thrown will tell the user what option to set.