### PR TITLE
Repack cvc4 lib in static library

### DIFF
--- a/cvc4/CMakeLists.txt
+++ b/cvc4/CMakeLists.txt
@@ -24,26 +24,30 @@ if (SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
   # we want the static library to include the cvc4 source
   # we need to unpack and repack the libraries
   # CVC4 was trickier because unpacking and repacking with ar seemed to lose info
-  # This uses a bash script that pipes and MRI command to ar
-  # It creates a new version of the static library and replaces the existing one
-  # NOTE: This might not work on Mac -- another option is the -T "thin" archive repacking
-  #       if that becomes a problem
-  #       Right now it's not a huge concern because static builds are discouraged on Mac
-  #       anyway
-  add_custom_target(repack-cvc4-static-lib
-    ALL
+  # the work around is to just copy libcvc4.a and add to it
+  add_custom_command(
+    OUTPUT static-smt-switch-cvc4.stamp
     COMMAND
-      mkdir smt-switch-cvc4 && cd smt-switch-cvc4 &&
-      "${PROJECT_SOURCE_DIR}/scripts/repack-static-lib.sh"
-      "$<TARGET_FILE_NAME:smt-switch-cvc4>"
-      "${CVC4_HOME}/build/src/libcvc4.a"
-      "${CVC4_HOME}/build/src/parser/libcvc4parser.a"
-      "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:smt-switch-cvc4>" &&
-      rm "../$<TARGET_FILE_NAME:smt-switch-cvc4>" && mv "./$<TARGET_FILE_NAME:smt-switch-cvc4>" ../ &&
-      # now clean up
-      cd ../ && rm -rf smt-switch-cvc4
+      mkdir ssc && cd ssc &&
+      ar -x "../$<TARGET_FILE_NAME:smt-switch-cvc4>" && cd ../
+      && rm "$<TARGET_FILE_NAME:smt-switch-cvc4>" &&
+      # copy the cvc4 static library to libsmt-switch-cvc4.a
+      cp "${CVC4_HOME}/build/src/libcvc4.a" "$<TARGET_FILE_NAME:smt-switch-cvc4>" &&
+      # add the smt-switch-cvc4 object files to the static library
+      bash -c "ar -rs $<TARGET_FILE_NAME:smt-switch-cvc4> ./ssc/*.o"
+      &&
+      # now clean up the temporary directory
+      rm -rf ssc
+    COMMAND ${CMAKE_COMMAND} -E touch static-smt-switch-cvc4.stamp
     DEPENDS
       smt-switch-cvc4
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    VERBATIM
+    )
+
+  add_custom_target(
+    repack-cvc4-static-lib ALL
+    DEPENDS static-smt-switch-cvc4.stamp
     )
 endif()
 

--- a/tests/cvc4/CMakeLists.txt
+++ b/tests/cvc4/CMakeLists.txt
@@ -13,6 +13,12 @@ set(CVC4_TESTS
 
 foreach(test ${CVC4_TESTS})
   add_executable(${test}.out ${test}.cpp)
+  if (SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
+    # make sure to use the repacked cvc4 static lib if built statically
+    # CVC4 was a special-case for bundling libcvc4.a into libsmt-switch-cvc4.a
+    # see cvc4/CMakeLists.txt from the top-level directory
+    add_dependencies(${test}.out repack-cvc4-static-lib)
+  endif()
   target_link_libraries(${test}.out smt-switch smt-switch-cvc4)
   target_link_libraries(${test}.out test-deps)
   add_test(${test} ${test}.out)


### PR DESCRIPTION
It's much more convenient to bundle the underlying solvers libraries into the static library. Then, a user can just link with `libsmt-switch.a` and `libsmt-switch-cvc4.a` without thinking about the `cvc4` specific dependencies.

CVC4 was a bit of a special-case because unpacking the object files with `ar` and re-adding them  did not work correctly (it had lots of complaints about undefined references). Originally, it was using the MRI script feature of `ar` but this did not work correctly on Mac. These changes us `ar` directly by first copying the static cvc4 library to `libsmt-switch-cvc4.a` and then adding the necessary object files for the `smt-switch` CVC4 wrapper.