### PR TITLE
Ensuring that it is clear which solvers are not BSD compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,14 @@ Some of the backend solvers have non-BSD compatible licenses. There are no provi
 Once you've configured the build system, simply enter the build directory (`./build` by default) and run `make`. Each solver you add produces a `libsmt-switch-<solver>.so` shared object file. Running `make install` installs these libraries and the public header files into the configured prefix (`/usr/local` by default). Note that the header files are put in a directory, e.g. `/usr/local/include/smt-switch`.
 
 ## Currently Supported Solvers
+
+### BSD compatible
+
 * Boolector
 * CVC4
+
+### Non-BSD compatible
+
 * MathSAT
 * Yices2
 


### PR DESCRIPTION
## Issue

When reading `README.md`, and after reading the section on BSD/non-BSD compatible solvers, it would be nice if the readme was explicit about which solvers are/aren't BSD compatible.

## Resolving

This PR segregates the "supported" solvers list into BSD compatible and non-BSD compatible.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>