### PR TITLE
Logging term compare fix

### DIFF
--- a/include/term_hashtable.h
+++ b/include/term_hashtable.h
@@ -35,6 +35,11 @@ class TermHashTable
   TermHashTable();
   ~TermHashTable();
   void insert(const Term & t);
+  /** check if a term is in the table
+   *  @param the term to check
+   *  @return true iff the term is already in the table
+   */
+  bool contains(const Term & t) const;
   /** lookup a term and modify pointer in place
    *  @param t the term to look up and modify
    *  @return true iff the term was found in the hash table

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -14,6 +14,8 @@
 **
 **/
 
+#include "assert.h"
+
 #include "logging_solver.h"
 #include "logging_sort.h"
 #include "logging_term.h"
@@ -277,6 +279,10 @@ Term LoggingSolver::make_term(const Op op, const Term & t) const
   shared_ptr<LoggingTerm> lt = static_pointer_cast<LoggingTerm>(t);
   Term wrapped_res = wrapped_solver->make_term(op, lt->wrapped_term);
   Sort res_logging_sort = compute_sort(op, this, { t->get_sort() });
+
+  // check that child is already in hash table
+  assert(hashtable->contains(t));
+
   Term res = std::make_shared<LoggingTerm>(
       wrapped_res, res_logging_sort, op, TermVec{ t });
 
@@ -302,6 +308,11 @@ Term LoggingSolver::make_term(const Op op,
       wrapped_solver->make_term(op, lt1->wrapped_term, lt2->wrapped_term);
   Sort res_logging_sort =
       compute_sort(op, this, { t1->get_sort(), t2->get_sort() });
+
+  // check that children are already in hash table
+  assert(hashtable->contains(t1));
+  assert(hashtable->contains(t2));
+
   Term res(
       new LoggingTerm(wrapped_res, res_logging_sort, op, TermVec{ t1, t2 }));
 
@@ -329,6 +340,12 @@ Term LoggingSolver::make_term(const Op op,
       op, lt1->wrapped_term, lt2->wrapped_term, lt3->wrapped_term);
   Sort res_logging_sort = compute_sort(
       op, this, { t1->get_sort(), t2->get_sort(), t3->get_sort() });
+
+  // check that children are already in hash table
+  assert(hashtable->contains(t1));
+  assert(hashtable->contains(t2));
+  assert(hashtable->contains(t3));
+
   Term res = std::make_shared<LoggingTerm>(
       wrapped_res, res_logging_sort, op, TermVec{ t1, t2, t3 });
 
@@ -351,6 +368,9 @@ Term LoggingSolver::make_term(const Op op, const TermVec & terms) const
   {
     shared_ptr<LoggingTerm> ltt = static_pointer_cast<LoggingTerm>(tt);
     lterms.push_back(ltt->wrapped_term);
+
+    // check that children are already in the hash table
+    assert(hashtable->contains(tt));
   }
   Term wrapped_res = wrapped_solver->make_term(op, lterms);
   // Note: for convenience there's a version of compute_sort that takes terms

--- a/src/logging_term.cpp
+++ b/src/logging_term.cpp
@@ -53,16 +53,18 @@ bool LoggingTerm::compare(const Term & t) const
   }
 
   shared_ptr<LoggingTerm> lt = static_pointer_cast<LoggingTerm>(t);
-  // compare op
-  if (op != lt->op)
+
+  // compare wrapped term and the LoggingSort
+  // this handles values (e.g. null operators and no children)
+  // and because of the sort comparison also handles sort aliasing
+  // of the wrapped solver
+  if (wrapped_term != lt->wrapped_term || sort != lt->sort)
   {
     return false;
   }
 
-  // compare underlying term and sort
-  // this will handle sort aliasing issues from solvers
-  // that don't distinguish between certain sorts
-  if (wrapped_term != lt->wrapped_term || sort != lt->sort)
+  // compare op
+  if (op != lt->op)
   {
     return false;
   }
@@ -77,7 +79,9 @@ bool LoggingTerm::compare(const Term & t) const
   {
     for (size_t i = 0; i < children.size(); i++)
     {
-      if (children[i] != lt->children[i])
+      // because of hash-consing, we can compare the pointers
+      // otherwise would recursively call compare on the LoggingTerm children
+      if (children[i].get() != lt->children[i].get())
       {
         return false;
       }

--- a/src/logging_term.cpp
+++ b/src/logging_term.cpp
@@ -61,7 +61,7 @@ bool LoggingTerm::compare(const Term & t) const
   // to compare children. See the use of .get() on the children below.
   // However, we do not just compare the pointer of this term with the argument
   // t. This is because we actually need to use this compare method for equality
-  // when looking up this term in the hash table to perform hash-consing
+  // when looking up this term in the hash table to perform hash-consing.
   // Thus, we cannot count on the pointers being equal for this term yet
   // only for the children which have already been resolved in the hash table.
 

--- a/src/logging_term.cpp
+++ b/src/logging_term.cpp
@@ -59,11 +59,16 @@ bool LoggingTerm::compare(const Term & t) const
   // which rely on this method for equality
   // Because we perform hash-consing, we can only compare the pointer values
   // to compare children. See the use of .get() on the children below.
-  // However, we do not just compare the pointer of this term with the argument
-  // t. This is because we actually need to use this compare method for equality
+  // However, we do not just compare the pointer value of this term with
+  // the pointer value of the argument t.
+  // This is because we actually need to use this compare method for equality
   // when looking up this term in the hash table to perform hash-consing.
-  // Thus, we cannot count on the pointers being equal for this term yet
-  // only for the children which have already been resolved in the hash table.
+  // which is done when constructing the term. At this point, it still has
+  // a different pointer value.
+  // Thus, we cannot count on the pointers of this term and the argument t
+  // to be equal. Instead we want to check that they represent the same term.
+  // which is true if the underlying terms are the same, and they both have
+  // the same Op, Sort, and children.
 
   if (!t)
   {

--- a/src/logging_term.cpp
+++ b/src/logging_term.cpp
@@ -46,6 +46,25 @@ LoggingTerm::~LoggingTerm() {}
 // implemented
 bool LoggingTerm::compare(const Term & t) const
 {
+  // This methods compares two LoggingTerms
+  // it is a particularly tricky implementation compared to the
+  // compare method in other implementations of AbsTerm
+  // If the underlying terms are different, then this will return false
+  // However, even if the underlying terms are the same, this might
+  // still need to return false. It needs to check that the sort,
+  // operator and children are the same to keep the contract that
+  // the logging term hides sort aliasing and term rewriting
+  // Furthermore, we want to avoid recursively calling compare
+  // on the whole term DAG because the children are also LoggingTerms
+  // which rely on this method for equality
+  // Because we perform hash-consing, we can only compare the pointer values
+  // to compare children. See the use of .get() on the children below.
+  // However, we do not just compare the pointer of this term with the argument
+  // t. This is because we actually need to use this compare method for equality
+  // when looking up this term in the hash table to perform hash-consing
+  // Thus, we cannot count on the pointers being equal for this term yet
+  // only for the children which have already been resolved in the hash table.
+
   if (!t)
   {
     // not equivalent to null term

--- a/src/logging_term.cpp
+++ b/src/logging_term.cpp
@@ -81,6 +81,10 @@ bool LoggingTerm::compare(const Term & t) const
     {
       // because of hash-consing, we can compare the pointers
       // otherwise would recursively call compare on the LoggingTerm children
+      // Note: calling get() intead of comparing the Term shared_ptrs directly
+      // because operator== is overloaded for Terms such that it uses the
+      // compare method of the underlying object (i.e. it would be a recursive
+      // call to compare)
       if (children[i].get() != lt->children[i].get())
       {
         return false;

--- a/src/term_hashtable.cpp
+++ b/src/term_hashtable.cpp
@@ -29,16 +29,21 @@ TermHashTable::~TermHashTable() {}
 
 void TermHashTable::insert(const Term & t) { table[t->hash()].insert(t); }
 
-bool TermHashTable::lookup(Term & t)
+bool TermHashTable::contains(const Term & t) const
 {
   size_t hashval = t->hash();
-  if (table.find(hashval) != table.end()
-      && table[hashval].find(t) != table[hashval].end())
+  return (table.find(hashval) != table.end()
+          && table.at(hashval).find(t) != table.at(hashval).end());
+}
+
+bool TermHashTable::lookup(Term & t)
+{
+  if (contains(t))
   {
     // reassign t
     // should destroy the previous Term
     // when reference counter goes to zero
-    t = *(table[hashval].find(t));
+    t = *(table[t->hash()].find(t));
     return true;
   }
   return false;


### PR DESCRIPTION
This is a fix for `LoggingTerm::compare`. This is used to test equality between `LoggingTerms`. Previously, it was checking that the wrapped term, op and sort were the same, and then checking that each of the children were the same. While technically correct, this was terrible for performance because the children are themselves `LoggingTerms`. Thus, equality comparison traversed the whole term DAG.

This PR adds a simple fix based on hash-consing (which was already performed before this PR). Because of hash-consing, we can simply compare the pointers. However, it's not quite that simple because to perform hash-consing we need to compare for equality to find the single pointer that is used for that term in the hash table. Thus, we can't use the pointer of the current term. But, we can use the pointers of the children. So, when checking the children for equality, we compare the pointers instead of using `LoggingTerm::compare`.

This PR also adds a few tests and adds hash table lookups in places they were missing.