### PR TITLE
Fix for constant array term iteration in CVC4 + tests

### DIFF
--- a/cvc4/include/cvc4_term.h
+++ b/cvc4/include/cvc4_term.h
@@ -45,7 +45,7 @@ namespace smt {
   {
   public:
    CVC4TermIter(::CVC4::api::Term term, uint32_t p = 0) : term(term), pos(p){};
-   CVC4TermIter(const CVC4TermIter & it) { term = term; };
+   CVC4TermIter(const CVC4TermIter & it) { term = it.term; };
    ~CVC4TermIter(){};
    CVC4TermIter & operator=(const CVC4TermIter & it);
    void operator++() override;
@@ -92,4 +92,3 @@ namespace smt {
 
 
 }
-

--- a/cvc4/include/cvc4_term.h
+++ b/cvc4/include/cvc4_term.h
@@ -44,22 +44,22 @@ namespace smt {
   class CVC4TermIter : public TermIterBase
   {
   public:
-    CVC4TermIter(const ::CVC4::api::Term::const_iterator term_it)
-      : term_it(term_it){};
-    CVC4TermIter(const CVC4TermIter & it) { term_it = it.term_it; };
-    ~CVC4TermIter() {};
-    CVC4TermIter & operator=(const CVC4TermIter & it);
-    void operator++() override;
-    const Term operator*() override;
-    TermIterBase * clone() const override;
-    bool operator==(const CVC4TermIter & it);
-    bool operator!=(const CVC4TermIter & it);
+   CVC4TermIter(::CVC4::api::Term term, uint32_t p = 0) : term(term), pos(p){};
+   CVC4TermIter(const CVC4TermIter & it) { term = term; };
+   ~CVC4TermIter(){};
+   CVC4TermIter & operator=(const CVC4TermIter & it);
+   void operator++() override;
+   const Term operator*() override;
+   TermIterBase * clone() const override;
+   bool operator==(const CVC4TermIter & it);
+   bool operator!=(const CVC4TermIter & it);
 
   protected:
     bool equal(const TermIterBase & other) const override;
 
   private:
-    ::CVC4::api::Term::const_iterator term_it;
+   ::CVC4::api::Term term;
+   uint32_t pos;
   };
 
   class CVC4Term : public AbsTerm

--- a/cvc4/include/cvc4_term.h
+++ b/cvc4/include/cvc4_term.h
@@ -45,7 +45,7 @@ namespace smt {
   {
   public:
    CVC4TermIter(::CVC4::api::Term term, uint32_t p = 0) : term(term), pos(p){};
-   CVC4TermIter(const CVC4TermIter & it) { term = it.term; };
+   CVC4TermIter(const CVC4TermIter & it) { term = it.term; pos = it.pos; };
    ~CVC4TermIter(){};
    CVC4TermIter & operator=(const CVC4TermIter & it);
    void operator++() override;

--- a/cvc4/src/cvc4_term.cpp
+++ b/cvc4/src/cvc4_term.cpp
@@ -119,48 +119,57 @@ CVC4::api::TermHashFunction termhash;
 /* CVC4TermIter implementation */
 CVC4TermIter & CVC4TermIter::operator=(const CVC4TermIter & it)
 {
-  term_it = it.term_it;
+  term = it.term;
+  pos = it.pos;
   return *this;
 }
 
-void CVC4TermIter::operator++() { term_it++; }
+void CVC4TermIter::operator++() { pos++; }
 
 const Term CVC4TermIter::operator*()
 {
+  if (pos == term.getNumChildren()
+      && term.getKind() == ::CVC4::api::Kind::CONST_ARRAY)
+  {
+    return std::make_shared<CVC4Term>(term.getConstArrayBase());
+  }
   // special-case for BOUND_VAR_LIST -- parameters bound by a quantifier
   // smt-switch guarantees that the length is only one by construction
-  ::CVC4::api::Term t = *term_it;
+  ::CVC4::api::Term t = term[pos];
   if (t.getKind() == ::CVC4::api::BOUND_VAR_LIST)
   {
     if (t.getNumChildren() != 1)
     {
       // smt-switch should only allow binding one parameter
       // otherwise, we need to flatten arbitrary nestings of quantifiers and
-      // BOUND_VAR_LISTs ofr term iteration
+      // BOUND_VAR_LISTs for term iteration
       throw InternalSolverException(
           "Expected exactly one bound variable in CVC4 BOUND_VAR_LIST");
     }
     return std::make_shared<CVC4Term>(t[0]);
   }
-  return std::make_shared<CVC4Term> (*term_it);
+  return std::make_shared<CVC4Term>(t);
 }
 
-TermIterBase * CVC4TermIter::clone() const { return new CVC4TermIter(term_it); }
+TermIterBase * CVC4TermIter::clone() const
+{
+  return new CVC4TermIter(term, pos);
+}
 
 bool CVC4TermIter::operator==(const CVC4TermIter & it)
 {
-  return term_it == it.term_it;
+  return term == it.term && pos == it.pos;
 }
 
 bool CVC4TermIter::operator!=(const CVC4TermIter & it)
 {
-  return term_it != term_it;
+  return term != term || pos != it.pos;
 }
 
 bool CVC4TermIter::equal(const TermIterBase & other) const
 {
   const CVC4TermIter & cti = static_cast<const CVC4TermIter &>(other);
-  return term_it == cti.term_it;
+  return term == cti.term && pos == cti.pos;
 }
 
 /* end CVC4TermIter implementation */
@@ -304,14 +313,17 @@ uint64_t CVC4Term::to_int() const
 
 /** Iterators for traversing the children
  */
-TermIter CVC4Term::begin()
-{
-  return TermIter(new CVC4TermIter(term.begin()));
-}
+TermIter CVC4Term::begin() { return TermIter(new CVC4TermIter(term, 0)); }
 
 TermIter CVC4Term::end()
 {
-  return TermIter(new CVC4TermIter(term.end()));
+  uint32_t num_children = term.getNumChildren();
+  if (term.getKind() == ::CVC4::api::Kind::CONST_ARRAY)
+  {
+    // base of constant array is the child
+    num_children++;
+  }
+  return TermIter(new CVC4TermIter(term, num_children));
 }
 
 std::string CVC4Term::print_value_as(SortKind sk)

--- a/cvc4/src/cvc4_term.cpp
+++ b/cvc4/src/cvc4_term.cpp
@@ -163,7 +163,7 @@ bool CVC4TermIter::operator==(const CVC4TermIter & it)
 
 bool CVC4TermIter::operator!=(const CVC4TermIter & it)
 {
-  return term != term || pos != it.pos;
+  return term != it.term || pos != it.pos;
 }
 
 bool CVC4TermIter::equal(const TermIterBase & other) const

--- a/src/term_translator.cpp
+++ b/src/term_translator.cpp
@@ -16,6 +16,7 @@
 
 #include <iterator>
 #include <sstream>
+#include "assert.h"
 
 #include "term_translator.h"
 
@@ -108,6 +109,7 @@ Term TermTranslator::transfer_term(const Term & term)
         if (s->get_sort_kind() == ARRAY)
         {
           // special case for const-array
+          assert(t->begin() != t->end());
           Term val = cache.at(*(t->begin()));
           if (s->get_sort_kind() != ARRAY)
           {

--- a/tests/cvc4/CMakeLists.txt
+++ b/tests/cvc4/CMakeLists.txt
@@ -23,3 +23,11 @@ foreach(test ${CVC4_TESTS})
   target_link_libraries(${test}.out test-deps)
   add_test(${test} ${test}.out)
 endforeach()
+
+# Google Test
+# TODO: move old tests to Google Test infrastructure
+
+add_executable(cvc4-term-iter "${PROJECT_SOURCE_DIR}/tests/cvc4/cvc4-term-iter.cpp")
+target_link_libraries(cvc4-term-iter gtest_main)
+target_link_libraries(cvc4-term-iter test-deps)
+add_test(NAME cvc4-term-iter_test COMMAND cvc4-term-iter)

--- a/tests/cvc4/cvc4-term-iter.cpp
+++ b/tests/cvc4/cvc4-term-iter.cpp
@@ -1,0 +1,60 @@
+/*********************                                                        */
+/*! \file cvc4-term-iter.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief
+**
+**
+**/
+
+#include <iostream>
+#include <memory>
+#include <vector>
+#include "assert.h"
+
+#include "gtest/gtest.h"
+
+#include "api/cvc4cpp.h"
+
+#include "cvc4_term.h"
+#include "smt.h"
+
+using namespace smt;
+using namespace std;
+
+TEST(CVC4TermIterTest, Copy)
+{
+  ::CVC4::api::Solver solver;
+  ::CVC4::api::Sort bvsort4 = solver.mkBitVectorSort(4);
+  ::CVC4::api::Sort funsort = solver.mkFunctionSort(bvsort4, bvsort4);
+
+  ::CVC4::api::Term x = solver.mkConst(bvsort4, "x");
+  ::CVC4::api::Term v = solver.mkConst(bvsort4, "v");
+  ::CVC4::api::Term f = solver.mkConst(funsort, "f");
+
+  ::CVC4::api::Term fx = solver.mkTerm(CVC4::api::APPLY_UF, f, x);
+  ::CVC4::api::Term fv = solver.mkTerm(CVC4::api::APPLY_UF, f, v);
+
+  CVC4TermIter it1(fx, 0);
+  CVC4TermIter it2(fx, 0);
+
+  // NOTE: can't use _EQ and _NE macros because
+  // it takes a const argument
+  EXPECT_TRUE(it1 == it2);
+
+  ++it2;
+  EXPECT_TRUE(it1 != it2);
+
+  CVC4TermIter it3(fv, 0);
+  EXPECT_TRUE(it1 != it3);
+
+  CVC4TermIter it4(it3);
+  EXPECT_TRUE(it1 != it4);
+}

--- a/tests/cvc4/cvc4-term-iter.cpp
+++ b/tests/cvc4/cvc4-term-iter.cpp
@@ -56,5 +56,6 @@ TEST(CVC4TermIterTest, Copy)
   EXPECT_TRUE(it1 != it3);
 
   CVC4TermIter it4(it3);
+  EXPECT_TRUE(it3 == it4);
   EXPECT_TRUE(it1 != it4);
 }

--- a/tests/unit/unit-arrays.cpp
+++ b/tests/unit/unit-arrays.cpp
@@ -49,20 +49,26 @@ TEST_P(UnitArrayTests, ConstArr)
   Term a = s->make_symbol("a", arrsort);
   Term zero = s->make_term(0, bvsort);
   Term constarr0 = s->make_term(zero, arrsort);
-  ASSERT_TRUE(constarr0->get_op().is_null());
+  EXPECT_TRUE(constarr0->get_op().is_null());
+  EXPECT_FALSE(constarr0->is_symbol());
+  EXPECT_TRUE(constarr0->is_value());
+  // should have one child -- the value
+  ASSERT_NE(constarr0->begin(), constarr0->end());
+  Term val = *(constarr0->begin());
+  EXPECT_EQ(val, zero);
 
   s->assert_formula(s->make_term(Equal, a, constarr0));
   Result r = s->check_sat();
 
-  ASSERT_TRUE(r.is_sat());
+  EXPECT_TRUE(r.is_sat());
   Term aval = s->get_value(a);
-  ASSERT_EQ(aval->get_sort(), constarr0->get_sort());
-  ASSERT_EQ(aval, constarr0);
+  EXPECT_EQ(aval->get_sort(), constarr0->get_sort());
+  EXPECT_EQ(aval, constarr0);
 
   Term out_const_base;
   UnorderedTermMap assignments = s->get_array_values(a, out_const_base);
-  ASSERT_TRUE(out_const_base);  // not null
-  ASSERT_EQ(out_const_base, zero);
+  EXPECT_TRUE(out_const_base);  // not null
+  EXPECT_EQ(out_const_base, zero);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/unit/unit-termiter.cpp
+++ b/tests/unit/unit-termiter.cpp
@@ -102,6 +102,26 @@ TEST_P(UnitTests, InputIterator)
   ASSERT_EQ(children[1], x);
 }
 
+TEST_P(UnitTests, CopyIter)
+{
+  Term x = s->make_symbol("x", bvsort);
+  Term f = s->make_symbol("f", funsort);
+  Term fx = s->make_term(Apply, f, x);
+
+  Term v = s->make_symbol("v", bvsort);
+  Term fv = s->make_term(Apply, f, v);
+
+  ASSERT_NE(fx, fv);
+
+  TermIter it1 = fx->begin();
+  TermIter it2 = fx->begin();
+  EXPECT_EQ(it1, it2);
+  TermIter it3 = fv->begin();
+  EXPECT_NE(it1, it3);
+  it2 = it3;
+  EXPECT_NE(it1, it2);
+}
+
 INSTANTIATE_TEST_SUITE_P(ParametrizedUnit,
                          UnitTests,
                          testing::ValuesIn(filter_solver_enums({ TERMITER })));

--- a/tests/unit/unit-termiter.cpp
+++ b/tests/unit/unit-termiter.cpp
@@ -102,26 +102,6 @@ TEST_P(UnitTests, InputIterator)
   ASSERT_EQ(children[1], x);
 }
 
-TEST_P(UnitTests, CopyIter)
-{
-  Term x = s->make_symbol("x", bvsort);
-  Term f = s->make_symbol("f", funsort);
-  Term fx = s->make_term(Apply, f, x);
-
-  Term v = s->make_symbol("v", bvsort);
-  Term fv = s->make_term(Apply, f, v);
-
-  ASSERT_NE(fx, fv);
-
-  TermIter it1 = fx->begin();
-  TermIter it2 = fx->begin();
-  EXPECT_EQ(it1, it2);
-  TermIter it3 = fv->begin();
-  EXPECT_NE(it1, it3);
-  it2 = it3;
-  EXPECT_NE(it1, it2);
-}
-
 INSTANTIATE_TEST_SUITE_P(ParametrizedUnit,
                          UnitTests,
                          testing::ValuesIn(filter_solver_enums({ TERMITER })));


### PR DESCRIPTION
Smt-switch uses term iteration to get the constant array base of a constant array. For example, if `t` is a constant array, the base is `*(t->begin())`. CVC4 does not have this same representation. Previously, term iteration for the CVC4 backend used the `::CVC4::api::Term::const_iterator` directly. This PR would instead pass the parent term and a position and use `operator[]` of the term object to get the children. There's a special case for constant arrays where the end position is increased by one and the first iterator returns the base array.