### PR TITLE
Return a Result instead of bool from get_interpolant

### DIFF
--- a/include/printing_solver.h
+++ b/include/printing_solver.h
@@ -62,10 +62,9 @@ class PrintingSolver : public AbsSmtSolver
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   void reset_assertions() override;
-  bool get_interpolant(const Term & A,
-                               const Term & B,
-                               Term & out_I) const override;
-
+  Result get_interpolant(const Term & A,
+                         const Term & B,
+                         Term & out_I) const override;
 
   /* Operators that are not printed 
    * For example, creating terms is not printed, but the

--- a/include/solver.h
+++ b/include/solver.h
@@ -355,14 +355,14 @@ class AbsSmtSolver
    * @param A the A term for a craig interpolant
    * @param B the B term for a craig interpolant
    * @param out_I the term to store the computed interpolant in
-   * @return true iff an interpolant was computed
+   * @return unsat    iff an interpolant was computed,
+   *         sat      iff the query was satisfiable,
+   *         unknown  iff interpolation failed
    *
-   * Throws an SmtException if the formula was actually sat or
-   *   if computing the interpolant failed.
    */
-  virtual bool get_interpolant(const Term & A,
-                               const Term & B,
-                               Term & out_I) const
+  virtual Result get_interpolant(const Term & A,
+                                 const Term & B,
+                                 Term & out_I) const
   {
     throw NotImplementedException("Interpolants are not supported by this solver.");
   }

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -157,9 +157,9 @@ class MsatInterpolatingSolver : public MsatSolver
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
   Term get_value(const Term & t) const override;
-  bool get_interpolant(const Term & A,
-                       const Term & B,
-                       Term & out_I) const override;
+  Result get_interpolant(const Term & A,
+                         const Term & B,
+                         Term & out_I) const override;
 };
 
 }  // namespace smt

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -1060,9 +1060,9 @@ Term MsatInterpolatingSolver::get_value(const Term & t) const
   throw IncorrectUsageException("Can't get values from interpolating solver");
 }
 
-bool MsatInterpolatingSolver::get_interpolant(const Term & A,
-                                              const Term & B,
-                                              Term & out_I) const
+Result MsatInterpolatingSolver::get_interpolant(const Term & A,
+                                                const Term & B,
+                                                Term & out_I) const
 {
   // reset the environment -- each interpolant is it's own separate call
   msat_reset_env(env);
@@ -1096,16 +1096,16 @@ bool MsatInterpolatingSolver::get_interpolant(const Term & A,
     else
     {
       out_I = Term(new MsatTerm(env, itp));
-      return true;
+      return Result(UNSAT);
     }
   }
   else if (res == MSAT_SAT)
   {
-    return false;
+    return Result(SAT);
   }
   else
   {
-    throw InternalSolverException("Failed when computing interpolant.");
+    return Result(UNKNOWN);
   }
 }
 

--- a/python/smt_switch_dec.pxi
+++ b/python/smt_switch_dec.pxi
@@ -118,7 +118,7 @@ cdef extern from "solver.h" namespace "smt":
         void reset_assertions() except +
         c_Term substitute(const c_Term term, const c_UnorderedTermMap & substitution_map) except +
         void dump_smt2(string filename) except +
-        bint get_interpolant(const c_Term & A, const c_Term & B, c_Term & out_I) except +
+        c_Result get_interpolant(const c_Term & A, const c_Term & B, c_Term & out_I) except +
 
 
 cdef class Op:

--- a/python/smt_switch_imp.pxi
+++ b/python/smt_switch_imp.pxi
@@ -402,13 +402,14 @@ cdef class SmtSolver:
         Get an interpolant for A, and B. Note: this will throw an exception if called
         on a solver that was not created with create_<solver>_interpolator
 
-        returns None if the interpolant could not be computed
+        returns None if the interpolant could not be computed or the query
+                was satisfiable
         '''
         cdef c_Term cI
         cdef Term I = Term(self)
 
-        success = dref(self.css).get_interpolant(A.ct, B.ct, cI)
-        if not success:
+        res = dref(self.css).get_interpolant(A.ct, B.ct, cI)
+        if not res.is_unsat():
             return None
         else:
             I.ct = cI

--- a/src/printing_solver.cpp
+++ b/src/printing_solver.cpp
@@ -273,9 +273,10 @@ void PrintingSolver::reset_assertions() {
   wrapped_solver->reset_assertions(); 
 }
 
-bool PrintingSolver::get_interpolant(const Term & A,
-                               const Term & B,
-                               Term & out_I) const {
+Result PrintingSolver::get_interpolant(const Term & A,
+                                       const Term & B,
+                                       Term & out_I) const
+{
   /* currently we only support printing msat interpolation commands.
    * The printing follows the internal implementation from msat_solver.h
    * in which the assertions are labeled by interpolation groups

--- a/tests/msat/msat-interpolants.cpp
+++ b/tests/msat/msat-interpolants.cpp
@@ -49,9 +49,9 @@ int main()
   Term A = s->make_term(And, s->make_term(Lt, x, y), s->make_term(Lt, y, z));
   Term B = s->make_term(Gt, x, z);
   Term I;
-  bool got_interpolant = s->get_interpolant(A, B, I);
+  Result r = s->get_interpolant(A, B, I);
 
-  if (got_interpolant)
+  if (r.is_unsat())
   {
     cout << "Found interpolant: " << I << endl;
   }
@@ -64,9 +64,9 @@ int main()
   // try getting a second interpolant with different A and B
   A = s->make_term(And, s->make_term(Gt, x, y), s->make_term(Gt, y, z));
   B = s->make_term(Lt, x, z);
-  got_interpolant = s->get_interpolant(A, B, I);
+  r = s->get_interpolant(A, B, I);
 
-  if (got_interpolant)
+  if (r.is_unsat())
   {
     cout << "Found interpolant: " << I << endl;
   }
@@ -77,8 +77,8 @@ int main()
   }
 
   // now try a satisfiable formula
-  got_interpolant = s->get_interpolant(A, s->make_term(Gt, x, z), I);
-  assert(!got_interpolant);
+  r = s->get_interpolant(A, s->make_term(Gt, x, z), I);
+  assert(r.is_sat());
 
   return 0;
 }

--- a/tests/msat/msat-printing.cpp
+++ b/tests/msat/msat-printing.cpp
@@ -70,7 +70,8 @@ int main()
   Term A = s->make_term(And, s->make_term(Lt, x, y), s->make_term(Lt, y, z));
   Term B = s->make_term(Gt, x, z);
   Term I;
-  bool got_interpolant = s->get_interpolant(A, B, I);
+  Result r = s->get_interpolant(A, B, I);
+  assert(r.is_unsat());
 
   string filename = "msat-printing.cpp-sample.smt2";
   std::ofstream out(filename.c_str());

--- a/tests/test_itp.cpp
+++ b/tests/test_itp.cpp
@@ -56,8 +56,8 @@ TEST_P(ItpTests, Test_ITP)
   B = itp->make_term(And, B, itp->make_term(Lt, z, x));
 
   Term I;
-  bool success = itp->get_interpolant(A, B, I);
-  ASSERT_TRUE(success);
+  Result r = itp->get_interpolant(A, B, I);
+  ASSERT_TRUE(r.is_unsat());
 
   UnorderedTermSet free_symbols = get_free_symbols(I);
 


### PR DESCRIPTION
Instead of returning a boolean for success upon getting an interplant and throwing an exception on a failure, it will now return a `Result`. If `UNSAT`, then the interpolant `I` should be populated. If `SAT` then the query was satisfiable and there is no interpolant. Finally, if the result is `UNKNOWN` there was a failure in the interpolation procedure (for example, no quantifier-free interplant could be found).

This will require updates to Pono, the CVC4 Sygus interpolant branch of smt-switch, and possibly other codebases that depend on this?