### PR TITLE
Hash string representation of mathsat simple type

### DIFF
--- a/msat/src/msat_sort.cpp
+++ b/msat/src/msat_sort.cpp
@@ -70,7 +70,8 @@ std::size_t MsatSort::hash() const
   }
   else
   {
-    throw NotImplementedException("Unknown MathSAT type.");
+    // assume it's a simple type and hash the string
+    return std::hash<std::string>()(std::string(msat_type_repr(type)));
   }
 
   return v;

--- a/msat/src/msat_sort.cpp
+++ b/msat/src/msat_sort.cpp
@@ -26,55 +26,8 @@ namespace smt {
 
 std::size_t MsatSort::hash() const
 {
-  // TODO: check this hash function
-  // mathsat doesn't hash types
-  // so we need to generate a type
-  std::size_t v = 1;
-
-  // giving lower 20 bits for representing a width if it's a bit-vector
-  size_t out_width;
-  msat_type idx_type;
-  msat_type elem_type;
-
-  if (msat_is_integer_type(env, type))
-  {
-    v = v << 20;
-  }
-  else if (msat_is_rational_type(env, type))
-  {
-    v = v << 21;
-  }
-  else if (msat_is_bool_type(env, type))
-  {
-    v = v << 22;
-  }
-  else if (msat_is_bv_type(env, type, &out_width))
-  {
-    v = v << 23;
-    v = v ^ out_width;
-  }
-  else if (msat_is_array_type(env, type, &idx_type, &elem_type))
-  {
-    v = v << 24;
-    v = v ^ MsatSort(env, idx_type).hash();
-    v = v ^ MsatSort(env, elem_type).hash();
-  }
-  else if (is_uf_type)
-  {
-    v = v << 25;
-    for (auto t : get_domain_sorts())
-    {
-      v = v ^ t->hash();
-    }
-    v = v ^ get_codomain_sort()->hash();
-  }
-  else
-  {
-    // assume it's a simple type and hash the string
-    return std::hash<std::string>()(std::string(msat_type_repr(type)));
-  }
-
-  return v;
+  // msat_type ptr is unique
+  return (size_t)type.repr;
 }
 
 uint64_t MsatSort::get_width() const

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,12 @@ target_link_libraries(unit-term gtest_main)
 target_link_libraries(unit-term test-deps)
 add_test(NAME unit-term_test COMMAND unit-term)
 
+add_executable(unit-sort "${PROJECT_SOURCE_DIR}/tests/unit/unit-sort.cpp")
+target_link_libraries(unit-sort gtest_main)
+target_link_libraries(unit-sort test-deps)
+add_test(NAME unit-sort_test COMMAND unit-sort)
+
+
 add_executable(unit-sort-inference "${PROJECT_SOURCE_DIR}/tests/unit/unit-sort-inference.cpp")
 target_link_libraries(unit-sort-inference gtest_main)
 target_link_libraries(unit-sort-inference test-deps)

--- a/tests/unit/unit-sort.cpp
+++ b/tests/unit/unit-sort.cpp
@@ -1,22 +1,111 @@
-#include <iostream>
-#include <memory>
+/*********************                                                        */
+/*! \file unit-sort.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Unit tests for sorts
+**
+**
+**/
 
-#include "assert.h"
-#include "sort.h"
+#include <utility>
+#include <vector>
+
+#include "available_solvers.h"
+#include "gtest/gtest.h"
+#include "smt.h"
 
 using namespace smt;
 using namespace std;
 
-bool kind2str_check()
+namespace smt_tests {
+
+TEST(SortKind, ToString)
 {
-  return ((to_string(ARRAY) == "ARRAY") && (to_string(BOOL) == "BOOL")
-          && (to_string(BV) == "BV") && (to_string(INT) == "INT")
-          && (to_string(REAL) == "REAL")
-          && (to_string(UNINTERPRETED) == "UNINTERPRETED"));
+  EXPECT_EQ(to_string(ARRAY), "ARRAY");
+  EXPECT_EQ(to_string(BOOL), "BOOL");
+  EXPECT_EQ(to_string(BV), "BV");
+  EXPECT_EQ(to_string(INT), "INT");
+  EXPECT_EQ(to_string(REAL), "REAL");
+  EXPECT_EQ(to_string(FUNCTION), "FUNCTION");
+  EXPECT_EQ(to_string(UNINTERPRETED), "UNINTERPRETED");
 }
 
-int main()
+class UnitSortTests : public ::testing::Test,
+                      public ::testing::WithParamInterface<SolverEnum>
 {
-  assert(kind2str_check());
-  assert(to_string(ARRAY) == "ARRAY");
+ protected:
+  void SetUp() override
+  {
+    s = create_solver(GetParam());
+
+    boolsort = s->make_sort(BOOL);
+    bvsort = s->make_sort(BV, 4);
+    funsort = s->make_sort(FUNCTION, SortVec{ bvsort, bvsort });
+    arrsort = s->make_sort(ARRAY, bvsort, bvsort);
+  }
+  SmtSolver s;
+  Sort boolsort, bvsort, funsort, arrsort;
+};
+
+class UnitSortArithTests : public UnitSortTests
+{
+ protected:
+  void SetUp() override
+  {
+    UnitSortTests::SetUp();
+    intsort = s->make_sort(INT);
+    realsort = s->make_sort(REAL);
+  }
+  Sort intsort, realsort;
+};
+
+TEST_P(UnitSortTests, SameSortDiffObj)
+{
+  Sort boolsort_2 = s->make_sort(BOOL);
+  EXPECT_EQ(boolsort->hash(), boolsort_2->hash());
+  EXPECT_EQ(boolsort, boolsort_2);
+
+  Sort bvsort_2 = s->make_sort(BV, 4);
+  EXPECT_EQ(bvsort->hash(), bvsort_2->hash());
+  EXPECT_EQ(bvsort, bvsort_2);
+
+  Sort funsort_2 = s->make_sort(FUNCTION, { bvsort, bvsort_2 });
+  EXPECT_EQ(funsort->hash(), funsort_2->hash());
+  EXPECT_EQ(funsort, funsort_2);
+
+  Sort arrsort_2 = s->make_sort(ARRAY, bvsort, bvsort_2);
+  EXPECT_EQ(arrsort->hash(), arrsort_2->hash());
+  EXPECT_EQ(arrsort, arrsort_2);
 }
+
+TEST_P(UnitSortTests, SortParams)
+{
+  EXPECT_EQ(bvsort->get_width(), 4);
+  EXPECT_EQ(arrsort->get_indexsort(), bvsort);
+  EXPECT_EQ(arrsort->get_elemsort(), bvsort);
+  // not every solver supports querying function types for domain/codomain yet
+}
+
+TEST_P(UnitSortArithTests, SameSortDiffObj)
+{
+  Sort intsort_2 = s->make_sort(INT);
+  EXPECT_EQ(intsort->hash(), intsort_2->hash());
+  EXPECT_EQ(intsort, intsort_2);
+
+  Sort realsort_2 = s->make_sort(REAL);
+  EXPECT_EQ(realsort->hash(), realsort_2->hash());
+  EXPECT_EQ(realsort, realsort_2);
+}
+
+INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSortTests,
+                         UnitSortTests,
+                         testing::ValuesIn(available_solver_enums()));
+
+}  // namespace smt_tests


### PR DESCRIPTION
MathSAT does not have ids for types. Thus the hash implementation for sorts in the MathSAT backend is custom and performed at the smt-switch level. It first determines the general type (e.g. Int, Array, etc...) and then incorporates the sort parameters into the hash.

However, MathSAT doesn't currently have a way to check if a given type is a simple type (declared sort). Thus, to implement hash for simple types, we just hash the string representation of the type.

Note: one danger here is that when new types are added, this could make it so the developer forgets to add a specialized hash for that type, and instead it always relies on the string. This should always still work but could possibly have a slight performance impact.