### PR TITLE
changes to unsat_core method

### DIFF
--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -62,7 +62,6 @@ class BoolectorSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(TermVec & out) override;
   void get_unsat_core(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;

--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -62,7 +62,8 @@ class BoolectorSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  TermVec get_unsat_core() override;
+  void get_unsat_core(TermVec & out) override;
+  void get_unsat_core(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -505,17 +505,26 @@ UnorderedTermMap BoolectorSolver::get_array_values(const Term & arr,
   return assignments;
 }
 
-TermVec BoolectorSolver::get_unsat_core()
+void BoolectorSolver::get_unsat_core(TermVec & out)
 {
-  TermVec core;
   BoolectorNode ** bcore = boolector_get_failed_assumptions(btor);
   while (*bcore)
   {
-    core.push_back(std::make_shared<BoolectorTerm>(
+    out.push_back(std::make_shared<BoolectorTerm>(
         btor, boolector_copy(btor, *bcore)));
     ++bcore;
   }
-  return core;
+}
+
+void BoolectorSolver::get_unsat_core(UnorderedTermSet & out)
+{
+  BoolectorNode ** bcore = boolector_get_failed_assumptions(btor);
+  while (*bcore)
+  {
+    out.insert(std::make_shared<BoolectorTerm>(
+        btor, boolector_copy(btor, *bcore)));
+    ++bcore;
+  }
 }
 
 Sort BoolectorSolver::make_sort(const std::string name, uint64_t arity) const

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -505,17 +505,6 @@ UnorderedTermMap BoolectorSolver::get_array_values(const Term & arr,
   return assignments;
 }
 
-void BoolectorSolver::get_unsat_core(TermVec & out)
-{
-  BoolectorNode ** bcore = boolector_get_failed_assumptions(btor);
-  while (*bcore)
-  {
-    out.push_back(std::make_shared<BoolectorTerm>(
-        btor, boolector_copy(btor, *bcore)));
-    ++bcore;
-  }
-}
-
 void BoolectorSolver::get_unsat_core(UnorderedTermSet & out)
 {
   BoolectorNode ** bcore = boolector_get_failed_assumptions(btor);

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -61,7 +61,8 @@ class CVC4Solver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  TermVec get_unsat_core() override;
+  void get_unsat_core(TermVec & out) override;
+  void get_unsat_core(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -61,7 +61,6 @@ class CVC4Solver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(TermVec & out) override;
   void get_unsat_core(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -412,15 +412,14 @@ UnorderedTermMap CVC4Solver::get_array_values(const Term & arr,
   }
 }
 
-TermVec CVC4Solver::get_unsat_core()
+void CVC4Solver::get_unsat_core(TermVec & out)
 {
-  TermVec core;
   Term f;
   try
   {
     for (auto cterm : solver.getUnsatAssumptions())
     {
-      core.push_back(std::make_shared<CVC4Term>(cterm));
+      out.push_back(std::make_shared<CVC4Term>(cterm));
     }
   }
   // this function seems to return a different exception type
@@ -428,7 +427,23 @@ TermVec CVC4Solver::get_unsat_core()
   {
     throw InternalSolverException(e.what());
   }
-  return core;
+}
+
+void CVC4Solver::get_unsat_core(UnorderedTermSet & out)
+{
+  Term f;
+  try
+  {
+    for (auto cterm : solver.getUnsatAssumptions())
+    {
+      out.insert(std::make_shared<CVC4Term>(cterm));
+    }
+  }
+  // this function seems to return a different exception type
+  catch (std::exception & e)
+  {
+    throw InternalSolverException(e.what());
+  }
 }
 
 Sort CVC4Solver::make_sort(const std::string name, uint64_t arity) const

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -412,23 +412,6 @@ UnorderedTermMap CVC4Solver::get_array_values(const Term & arr,
   }
 }
 
-void CVC4Solver::get_unsat_core(TermVec & out)
-{
-  Term f;
-  try
-  {
-    for (auto cterm : solver.getUnsatAssumptions())
-    {
-      out.push_back(std::make_shared<CVC4Term>(cterm));
-    }
-  }
-  // this function seems to return a different exception type
-  catch (std::exception & e)
-  {
-    throw InternalSolverException(e.what());
-  }
-}
-
 void CVC4Solver::get_unsat_core(UnorderedTermSet & out)
 {
   Term f;

--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -72,7 +72,6 @@ class LoggingSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(TermVec & out) override;
   void get_unsat_core(UnorderedTermSet & out) override;
   // Will probably remove this eventually
   // For now, need to clear the hash table

--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -72,7 +72,8 @@ class LoggingSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  TermVec get_unsat_core() override;
+  void get_unsat_core(TermVec & out) override;
+  void get_unsat_core(UnorderedTermSet & out) override;
   // Will probably remove this eventually
   // For now, need to clear the hash table
   void reset() override;

--- a/include/printing_solver.h
+++ b/include/printing_solver.h
@@ -52,7 +52,8 @@ class PrintingSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  TermVec get_unsat_core() override;
+  void get_unsat_core(TermVec & out) override;
+  void get_unsat_core(UnorderedTermSet & out) override;
   void reset() override;
   void set_opt(const std::string option, const std::string value) override;
   void set_logic(const std::string logic) override;

--- a/include/printing_solver.h
+++ b/include/printing_solver.h
@@ -52,7 +52,6 @@ class PrintingSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(TermVec & out) override;
   void get_unsat_core(UnorderedTermSet & out) override;
   void reset() override;
   void set_opt(const std::string option, const std::string value) override;

--- a/include/solver.h
+++ b/include/solver.h
@@ -109,7 +109,6 @@ class AbsSmtSolver
    *  unsat.
    *  SMTLIB: (get-unsat-assumptions) 
    */
-  virtual void get_unsat_core(TermVec & out) = 0;
   virtual void get_unsat_core(UnorderedTermSet & out) = 0;
 
   // virtual bool check_sat_assuming() const = 0;

--- a/include/solver.h
+++ b/include/solver.h
@@ -106,8 +106,8 @@ class AbsSmtSolver
   /** After a call to check_sat_assuming that returns an unsatisfiable result
    *  this function will populate the out TermVec/UnorderedTermSet with a subset
    *  of the assumption literals that are sufficient to make the assertions
-   *  unsat. SMTLIB: (get-unsat-assumptions) @return a vector of assumption
-   *  literals in the unsat core
+   *  unsat.
+   *  SMTLIB: (get-unsat-assumptions) 
    */
   virtual void get_unsat_core(TermVec & out) = 0;
   virtual void get_unsat_core(UnorderedTermSet & out) = 0;

--- a/include/solver.h
+++ b/include/solver.h
@@ -104,12 +104,13 @@ class AbsSmtSolver
                                             Term & out_const_base) const = 0;
 
   /** After a call to check_sat_assuming that returns an unsatisfiable result
-   *  this function will return a subset of the assumption literals
-   *  that are sufficient to make the assertions unsat.
-   *  SMTLIB: (get-unsat-assumptions)
-   *  @return a vector of assumption literals in the unsat core
+   *  this function will populate the out TermVec/UnorderedTermSet with a subset
+   *  of the assumption literals that are sufficient to make the assertions
+   *  unsat. SMTLIB: (get-unsat-assumptions) @return a vector of assumption
+   *  literals in the unsat core
    */
-  virtual TermVec get_unsat_core() = 0;
+  virtual void get_unsat_core(TermVec & out) = 0;
+  virtual void get_unsat_core(UnorderedTermSet & out) = 0;
 
   // virtual bool check_sat_assuming() const = 0;
 

--- a/include/solver.h
+++ b/include/solver.h
@@ -104,7 +104,7 @@ class AbsSmtSolver
                                             Term & out_const_base) const = 0;
 
   /** After a call to check_sat_assuming that returns an unsatisfiable result
-   *  this function will populate the out TermVec/UnorderedTermSet with a subset
+   *  this function will populate the 'out' UnorderedTermSet with a subset
    *  of the assumption literals that are sufficient to make the assertions
    *  unsat.
    *  SMTLIB: (get-unsat-assumptions) 

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -74,7 +74,6 @@ class MsatSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(TermVec & out) override;
   void get_unsat_core(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -74,7 +74,8 @@ class MsatSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  TermVec get_unsat_core() override;
+  void get_unsat_core(TermVec & out) override;
+  void get_unsat_core(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -310,9 +310,8 @@ UnorderedTermMap MsatSolver::get_array_values(const Term & arr,
   return assignments;
 }
 
-TermVec MsatSolver::get_unsat_core()
+void MsatSolver::get_unsat_core(TermVec & out)
 {
-  TermVec core;
   size_t core_size;
   msat_term * mcore = msat_get_unsat_assumptions(env, &core_size);
   if (!mcore || !core_size)
@@ -325,11 +324,30 @@ TermVec MsatSolver::get_unsat_core()
   msat_term * mcore_iter = mcore;
   for (size_t i = 0; i < core_size; ++i)
   {
-    core.push_back(std::make_shared<MsatTerm>(env, *mcore_iter));
+    out.push_back(std::make_shared<MsatTerm>(env, *mcore_iter));
     ++mcore_iter;
   }
   msat_free(mcore);
-  return core;
+}
+
+void MsatSolver::get_unsat_core(UnorderedTermSet & out)
+{
+  size_t core_size;
+  msat_term * mcore = msat_get_unsat_assumptions(env, &core_size);
+  if (!mcore || !core_size)
+  {
+    throw InternalSolverException(
+        "Got an empty unsat core. Ensure your last call was unsat and had "
+        "assumptions in check_sat_assuming that are required to get an unsat "
+        "result");
+  }
+  msat_term * mcore_iter = mcore;
+  for (size_t i = 0; i < core_size; ++i)
+  {
+    out.insert(std::make_shared<MsatTerm>(env, *mcore_iter));
+    ++mcore_iter;
+  }
+  msat_free(mcore);
 }
 
 Sort MsatSolver::make_sort(const std::string name, uint64_t arity) const

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -310,26 +310,6 @@ UnorderedTermMap MsatSolver::get_array_values(const Term & arr,
   return assignments;
 }
 
-void MsatSolver::get_unsat_core(TermVec & out)
-{
-  size_t core_size;
-  msat_term * mcore = msat_get_unsat_assumptions(env, &core_size);
-  if (!mcore || !core_size)
-  {
-    throw InternalSolverException(
-        "Got an empty unsat core. Ensure your last call was unsat and had "
-        "assumptions in check_sat_assuming that are required to get an unsat "
-        "result");
-  }
-  msat_term * mcore_iter = mcore;
-  for (size_t i = 0; i < core_size; ++i)
-  {
-    out.push_back(std::make_shared<MsatTerm>(env, *mcore_iter));
-    ++mcore_iter;
-  }
-  msat_free(mcore);
-}
-
 void MsatSolver::get_unsat_core(UnorderedTermSet & out)
 {
   size_t core_size;

--- a/python/smt_switch_dec.pxi
+++ b/python/smt_switch_dec.pxi
@@ -101,7 +101,6 @@ cdef extern from "solver.h" namespace "smt":
         void push(uint64_t num) except +
         void pop(uint64_t num) except +
         c_Term get_value(c_Term& t) except +
-        void get_unsat_core(c_TermVec& out) except +
         void get_unsat_core(c_UnorderedTermSet& out) except +
         c_Sort make_sort(const string name, uint64_t arity) except +
         c_Sort make_sort(const c_SortKind sk) except +

--- a/python/smt_switch_dec.pxi
+++ b/python/smt_switch_dec.pxi
@@ -2,6 +2,7 @@ from libc.stdint cimport int32_t, int64_t, uint32_t, uint64_t
 from libcpp.memory cimport shared_ptr
 from libcpp.string cimport string
 from libcpp.unordered_map cimport unordered_map
+from libcpp.unordered_set cimport unordered_set
 from libcpp.vector cimport vector
 
 from smt_switch cimport c_PrimOp, c_SortKind
@@ -11,6 +12,7 @@ ctypedef shared_ptr[AbsTerm] c_Term
 ctypedef shared_ptr[AbsSmtSolver] c_SmtSolver
 ctypedef vector[c_Sort] c_SortVec
 ctypedef vector[c_Term] c_TermVec
+ctypedef unordered_set[c_Term] c_UnorderedTermSet
 ctypedef unordered_map[c_Term, c_Term] c_UnorderedTermMap
 
 
@@ -99,7 +101,8 @@ cdef extern from "solver.h" namespace "smt":
         void push(uint64_t num) except +
         void pop(uint64_t num) except +
         c_Term get_value(c_Term& t) except +
-        c_TermVec get_unsat_core() except +
+        void get_unsat_core(c_TermVec& out) except +
+        void get_unsat_core(c_UnorderedTermSet& out) except +
         c_Sort make_sort(const string name, uint64_t arity) except +
         c_Sort make_sort(const c_SortKind sk) except +
         c_Sort make_sort(const c_SortKind sk, uint64_t size) except +

--- a/python/smt_switch_imp.pxi
+++ b/python/smt_switch_imp.pxi
@@ -282,7 +282,9 @@ cdef class SmtSolver:
 
     def get_unsat_core(self):
         unsat_core = []
-        for l in dref(self.css).get_unsat_core():
+        cdef c_TermVec ctv
+        dref(self.css).get_unsat_core(ctv)
+        for l in ctv:
             term = Term(self)
             term.ct = l
             unsat_core.append(term)

--- a/python/smt_switch_imp.pxi
+++ b/python/smt_switch_imp.pxi
@@ -281,7 +281,7 @@ cdef class SmtSolver:
         return term
 
     def get_unsat_core(self):
-        unsat_core = {}
+        unsat_core = set()
         cdef c_UnorderedTermSet cts
         dref(self.css).get_unsat_core(cts)
         for l in cts:

--- a/python/smt_switch_imp.pxi
+++ b/python/smt_switch_imp.pxi
@@ -281,13 +281,13 @@ cdef class SmtSolver:
         return term
 
     def get_unsat_core(self):
-        unsat_core = []
-        cdef c_TermVec ctv
-        dref(self.css).get_unsat_core(ctv)
-        for l in ctv:
+        unsat_core = {}
+        cdef c_UnorderedTermSet cts
+        dref(self.css).get_unsat_core(cts)
+        for l in cts:
             term = Term(self)
             term.ct = l
-            unsat_core.append(term)
+            unsat_core.add(term)
         return unsat_core
 
     def make_sort(self, arg0, arg1=None, arg2=None, arg3=None):

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -438,26 +438,6 @@ Term LoggingSolver::get_value(const Term & t) const
   return res;
 }
 
-void LoggingSolver::get_unsat_core(TermVec & out)
-{
-  TermVec underlying_core;
-  wrapped_solver->get_unsat_core(underlying_core);
-  for (auto c : underlying_core)
-  {
-    // assumption: these should be (possible negated) Boolean literals
-    // that were used in check_sat_assuming
-    // assumption_cache stored a mapping so we can recover the logging term
-    if (assumption_cache->find(c) == assumption_cache->end())
-    {
-      throw InternalSolverException(
-          "Got an element in the unsat core that was not cached from "
-          "check_sat_assuming in LoggingSolver.");
-    }
-    Term log_c = assumption_cache->at(c);
-    out.push_back(log_c);
-  }
-}
-
 void LoggingSolver::get_unsat_core(UnorderedTermSet & out)
 {
   UnorderedTermSet underlying_core;

--- a/src/printing_solver.cpp
+++ b/src/printing_solver.cpp
@@ -202,12 +202,17 @@ Term PrintingSolver::get_value(const Term & t) const
   return wrapped_solver->get_value(t);
 }
 
-TermVec PrintingSolver::get_unsat_core()
+void PrintingSolver::get_unsat_core(TermVec & out)
 {
   (*out_stream) << "(" << GET_UNSAT_ASSUMPTIONS_STR << ")" << endl;
-  return wrapped_solver->get_unsat_core();
+  wrapped_solver->get_unsat_core(out);
 }
 
+void PrintingSolver::get_unsat_core(UnorderedTermSet & out)
+{
+  (*out_stream) << "(" << GET_UNSAT_ASSUMPTIONS_STR << ")" << endl;
+  wrapped_solver->get_unsat_core(out);
+}
 
 UnorderedTermMap PrintingSolver::get_array_values(const Term & arr,
                                                  Term & out_const_base) const

--- a/src/printing_solver.cpp
+++ b/src/printing_solver.cpp
@@ -202,12 +202,6 @@ Term PrintingSolver::get_value(const Term & t) const
   return wrapped_solver->get_value(t);
 }
 
-void PrintingSolver::get_unsat_core(TermVec & out)
-{
-  (*out_stream) << "(" << GET_UNSAT_ASSUMPTIONS_STR << ")" << endl;
-  wrapped_solver->get_unsat_core(out);
-}
-
 void PrintingSolver::get_unsat_core(UnorderedTermSet & out)
 {
   (*out_stream) << "(" << GET_UNSAT_ASSUMPTIONS_STR << ")" << endl;

--- a/tests/cvc4/cvc4-printing.cpp
+++ b/tests/cvc4/cvc4-printing.cpp
@@ -89,7 +89,8 @@ int main()
                                              s->make_term(Select, arr, y)))));
   Result r = s->check_sat_assuming(TermVec{ ind1 });
   assert(r.is_unsat());
-  TermVec usc = s->get_unsat_core();
+  UnorderedTermSet usc;
+  s->get_unsat_core(usc);
   s->pop(1);
   s->check_sat();
   s->get_value(x);

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -53,7 +53,7 @@ TEST_P(UnsatCoreTests, UnsatCore)
   Result r = s->check_sat_assuming({ a, b, s->make_term(Not, b) });
   ASSERT_TRUE(r.is_unsat());
 
-  TermVec core;
+  UnorderedTermSet core;
   s->get_unsat_core(core);
   ASSERT_TRUE(core.size() > 1);
 

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -53,14 +53,15 @@ TEST_P(UnsatCoreTests, UnsatCore)
   Result r = s->check_sat_assuming({ a, b, s->make_term(Not, b) });
   ASSERT_TRUE(r.is_unsat());
 
-  TermVec core = s->get_unsat_core();
+  TermVec core;
+  s->get_unsat_core(core);
   ASSERT_TRUE(core.size() > 1);
 
   // for solvers using assumptions under the hood,
   // make sure they are re-added correctly
   r = s->check_sat();
   ASSERT_TRUE(r.is_sat());
-  ASSERT_THROW(core = s->get_unsat_core(), SmtException);
+  ASSERT_THROW(s->get_unsat_core(core), SmtException);
   s->pop();
 }
 

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -68,7 +68,6 @@ class Yices2Solver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(TermVec & out) override;
   void get_unsat_core(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -68,7 +68,8 @@ class Yices2Solver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  TermVec get_unsat_core() override;
+  void get_unsat_core(TermVec & out) override;
+  void get_unsat_core(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -413,30 +413,6 @@ UnorderedTermMap Yices2Solver::get_array_values(const Term & arr,
       "particular select of the array.");
 }
 
-void Yices2Solver::get_unsat_core(TermVec & out)
-{
-  term_vector_t ycore;
-  yices_init_term_vector(&ycore);
-  int32_t err_code = yices_get_unsat_core(ctx, &ycore);
-  // yices2 documentation: returns -1 if ctx status was not UNSAT
-  if (err_code == -1)
-  {
-    throw IncorrectUsageException(
-        "Last call to check_sat was not unsat, cannot get unsat core.");
-  }
-
-  for (size_t i = 0; i < ycore.size; ++i)
-  {
-    if (!ycore.data[i])
-    {
-      throw InternalSolverException("Got an empty term from vector");
-    }
-    out.push_back(std::make_shared<Yices2Term>(ycore.data[i]));
-  }
-
-  yices_delete_term_vector(&ycore);
-}
-
 void Yices2Solver::get_unsat_core(UnorderedTermSet & out)
 {
   term_vector_t ycore;


### PR DESCRIPTION
This PR makes the following update
- instead of returning a TermVec, the get_unsat_core method takes a reference of either a TermVec or a UnorderedTermSet as an argument. 

This change will make the method more memory-friendly.