### PR TITLE
constant rationals support in transfer_term

### DIFF
--- a/include/term_translator.h
+++ b/include/term_translator.h
@@ -94,6 +94,13 @@ class TermTranslator
    *  @return a term with the given value
    */
   Term value_from_smt2(const std::string val, const Sort sort) const;
+  
+  /** translates an smtlib representation of a const rational "(/ a b)"
+   *  into a mathsat-style representation of a const rational "a / b"
+   * @param smtlib is the smtlib representation
+   * @return the mathsat-style representation
+   */
+  std::string mathsatize_rational(const std::string smtlib) const;
 
   /** identifies relevant casts to perform an operation
    *  assumes the operation is currently not well-sorted

--- a/include/term_translator.h
+++ b/include/term_translator.h
@@ -96,11 +96,11 @@ class TermTranslator
   Term value_from_smt2(const std::string val, const Sort sort) const;
   
   /** translates an smtlib representation of a const rational "(/ a b)"
-   *  into a mathsat-style representation of a const rational "a / b"
+   *  into a infix-style representation of a const rational "a / b"
    * @param smtlib is the smtlib representation
-   * @return the mathsat-style representation
+   * @return the infix-style representation
    */
-  std::string mathsatize_rational(const std::string smtlib) const;
+  std::string infixize_rational(const std::string smtlib) const;
 
   /** identifies relevant casts to perform an operation
    *  assumes the operation is currently not well-sorted

--- a/src/term_translator.cpp
+++ b/src/term_translator.cpp
@@ -279,11 +279,10 @@ std::string TermTranslator::mathsatize_rational(const std::string smtlib) const 
     int ind_of_up_end = smtlib.find_first_of(' ', ind_of_up_start);
   assert(ind_of_up_end != std::string::npos);
   ind_of_up_end -= 1;
-  int ind_of_down_start = ind_of_up_end + 2; 
+  int ind_of_down_start = ind_of_up_end + 2;
   int ind_of_down_end = smtlib.find_first_of(')', ind_of_down_start);
   assert(ind_of_down_end != std::string::npos);
   ind_of_down_end -= 1;
-  
   std::string new_up = smtlib.substr(ind_of_up_start, ind_of_up_end - ind_of_up_start +1);
   std::string new_down = smtlib.substr(ind_of_down_start, ind_of_down_end - ind_of_down_start +1);
   std::string new_string = new_up + " " + op + " " + new_down;

--- a/src/term_translator.cpp
+++ b/src/term_translator.cpp
@@ -266,7 +266,7 @@ Term TermTranslator::transfer_term(const Term & term, const SortKind sk)
   }
 }
 
-std::string TermTranslator::mathsatize_rational(const std::string smtlib) const {
+std::string TermTranslator::infixize_rational(const std::string smtlib) const {
   // smtlib: (/ up down)
   // ind -- index
   std::string op;
@@ -341,13 +341,13 @@ Term TermTranslator::value_from_smt2(const std::string val,
     if (val.substr(0, 2) == "(-")
     {
       std::string posval = val.substr(3, val.length() - 4);
-      posval = mathsatize_rational(posval);
+      posval = infixize_rational(posval);
       Term posterm = solver->make_term(posval, sort);
       return solver->make_term(Negate, posterm);
     }
     else
     {
-      std::string mval = mathsatize_rational(val);
+      std::string mval = infixize_rational(val);
       return solver->make_term(mval, sort);
     }
   }

--- a/src/term_translator.cpp
+++ b/src/term_translator.cpp
@@ -266,23 +266,17 @@ Term TermTranslator::transfer_term(const Term & term, const SortKind sk)
   }
 }
 
-std::string mathsatize(std::string smtlib) {
+std::string TermTranslator::mathsatize_rational(const std::string smtlib) const {
   // smtlib: (/ up down)
   // ind -- index
   std::string op;
   int ind_of_up_start = smtlib.find_first_of("/");
-  if (ind_of_up_start != std::string::npos) {
-    ind_of_up_start += 2;
-    op = "/";
-  } else {
-    ind_of_up_start = smtlib.find_first_of("mod");
-    if (ind_of_up_start == std::string::npos) {
-      return smtlib;
-    }
-    ind_of_up_start += 4;
-    op = "mod";
+  if (ind_of_up_start == std::string::npos) {
+    return smtlib;
   }
-  int ind_of_up_end = smtlib.find_first_of(' ', ind_of_up_start);
+  ind_of_up_start += 2;
+  op = "/";
+    int ind_of_up_end = smtlib.find_first_of(' ', ind_of_up_start);
   assert(ind_of_up_end != std::string::npos);
   ind_of_up_end -= 1;
   int ind_of_down_start = ind_of_up_end + 2; 
@@ -348,13 +342,13 @@ Term TermTranslator::value_from_smt2(const std::string val,
     if (val.substr(0, 2) == "(-")
     {
       std::string posval = val.substr(3, val.length() - 4);
-      posval = mathsatize(posval);
+      posval = mathsatize_rational(posval);
       Term posterm = solver->make_term(posval, sort);
       return solver->make_term(Negate, posterm);
     }
     else
     {
-      std::string mval = mathsatize(val);
+      std::string mval = mathsatize_rational(val);
       return solver->make_term(mval, sort);
     }
   }

--- a/src/term_translator.cpp
+++ b/src/term_translator.cpp
@@ -276,7 +276,7 @@ std::string TermTranslator::infixize_rational(const std::string smtlib) const {
   }
   ind_of_up_start += 2;
   op = "/";
-    int ind_of_up_end = smtlib.find_first_of(' ', ind_of_up_start);
+  int ind_of_up_end = smtlib.find_first_of(' ', ind_of_up_start);
   assert(ind_of_up_end != std::string::npos);
   ind_of_up_end -= 1;
   int ind_of_down_start = ind_of_up_end + 2;


### PR DESCRIPTION
When transferring a term, constant rationals are created using a string of the form `(/ a b)`, while some solvers expect a string of the form `a / b`.
Specifically, `mathsat` expects `a / b` while `cvc4` can handle both forms. `yices2` currently does not transfer terms (does not have a `begin` function for the iterator) and `boolector` does not support arith. Hence I just used the infix notation. 