### PR TITLE
Add get_arity and notion of a sort constructor

### DIFF
--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -75,8 +75,7 @@ class BoolectorSolver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(SortKind sk, const SortVec & sorts) const override;
-  Sort make_sort(const Sort & uninterp_sort,
-                 const SortVec & sorts) const override;
+  Sort make_sort(const Sort & sort_con, const SortVec & sorts) const override;
   Sort make_sort(const DatatypeDecl & d) const override;
 
   DatatypeDecl make_datatype_decl(const std::string & s) override;

--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -75,7 +75,8 @@ class BoolectorSolver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(SortKind sk, const SortVec & sorts) const override;
-
+  Sort make_sort(const Sort & uninterp_sort,
+                 const SortVec & sorts) const override;
   Sort make_sort(const DatatypeDecl & d) const override;
 
   DatatypeDecl make_datatype_decl(const std::string & s) override;

--- a/btor/include/boolector_sort.h
+++ b/btor/include/boolector_sort.h
@@ -40,8 +40,9 @@ class BoolectorSortBase : public AbsSort
   SortVec get_domain_sorts() const override;
   Sort get_codomain_sort() const override;
   std::string get_uninterpreted_name() const override;
-  Datatype get_datatype() const override;
   size_t get_arity() const override;
+  SortVec get_uninterpreted_param_sorts() const override;
+  Datatype get_datatype() const override;
   bool compare(const Sort s) const override;
   SortKind get_sort_kind() const override { return sk; };
 

--- a/btor/include/boolector_sort.h
+++ b/btor/include/boolector_sort.h
@@ -41,6 +41,7 @@ class BoolectorSortBase : public AbsSort
   Sort get_codomain_sort() const override;
   std::string get_uninterpreted_name() const override;
   Datatype get_datatype() const override;
+  size_t get_arity() const override;
   bool compare(const Sort s) const override;
   SortKind get_sort_kind() const override { return sk; };
 

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -645,6 +645,14 @@ Sort BoolectorSolver::make_sort(SortKind sk, const SortVec & sorts) const
   }
 }
 
+Sort BoolectorSolver::make_sort(const Sort & uninterp_sort,
+                                const SortVec & sorts) const
+
+{
+  throw IncorrectUsageException(
+      "Boolector does not support uninterpreted sort construction");
+}
+
 Term BoolectorSolver::make_symbol(const std::string name, const Sort & sort)
 {
   // check that name is available

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -645,7 +645,7 @@ Sort BoolectorSolver::make_sort(SortKind sk, const SortVec & sorts) const
   }
 }
 
-Sort BoolectorSolver::make_sort(const Sort & uninterp_sort,
+Sort BoolectorSolver::make_sort(const Sort & sort_con,
                                 const SortVec & sorts) const
 
 {

--- a/btor/src/boolector_sort.cpp
+++ b/btor/src/boolector_sort.cpp
@@ -75,16 +75,22 @@ std::string BoolectorSortBase::get_uninterpreted_name() const
       "Boolector doesn't support uninterpreted sorts.");
 }
 
-
-Datatype BoolectorSortBase::get_datatype() const {
-  throw NotImplementedException("get_datatype");
-};
-
 size_t BoolectorSortBase::get_arity() const
 {
   throw NotImplementedException(
       "Boolector does not support uninterpreted sorts");
 }
+
+SortVec BoolectorSortBase::get_uninterpreted_param_sorts() const
+{
+  throw NotImplementedException(
+      "Boolector does not support uninterpreted sorts.");
+}
+
+Datatype BoolectorSortBase::get_datatype() const
+{
+  throw NotImplementedException("get_datatype");
+};
 
 bool BoolectorSortBase::compare(const Sort s) const
 {

--- a/btor/src/boolector_sort.cpp
+++ b/btor/src/boolector_sort.cpp
@@ -80,6 +80,11 @@ Datatype BoolectorSortBase::get_datatype() const {
   throw NotImplementedException("get_datatype");
 };
 
+size_t BoolectorSortBase::get_arity() const
+{
+  throw NotImplementedException(
+      "Boolector does not support uninterpreted sorts");
+}
 
 bool BoolectorSortBase::compare(const Sort s) const
 {

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -74,8 +74,7 @@ class CVC4Solver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(SortKind sk, const SortVec & sorts) const override;
-  Sort make_sort(const Sort & uninterp_sort,
-                 const SortVec & sorts) const override;
+  Sort make_sort(const Sort & sort_con, const SortVec & sorts) const override;
   Sort make_sort(const DatatypeDecl & d) const override;
 
   DatatypeDecl make_datatype_decl(const std::string & s) override;

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -74,6 +74,8 @@ class CVC4Solver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(SortKind sk, const SortVec & sorts) const override;
+  Sort make_sort(const Sort & uninterp_sort,
+                 const SortVec & sorts) const override;
   Sort make_sort(const DatatypeDecl & d) const override;
 
   DatatypeDecl make_datatype_decl(const std::string & s) override;

--- a/cvc4/include/cvc4_sort.h
+++ b/cvc4/include/cvc4_sort.h
@@ -43,6 +43,7 @@ namespace smt
     Sort get_codomain_sort() const override;
     std::string get_uninterpreted_name() const override;
     Datatype get_datatype() const override;
+    size_t get_arity() const override;
     bool compare(const Sort) const override;
     SortKind get_sort_kind() const override;
 

--- a/cvc4/include/cvc4_sort.h
+++ b/cvc4/include/cvc4_sort.h
@@ -42,8 +42,9 @@ namespace smt
     SortVec get_domain_sorts() const override;
     Sort get_codomain_sort() const override;
     std::string get_uninterpreted_name() const override;
-    Datatype get_datatype() const override;
     size_t get_arity() const override;
+    SortVec get_uninterpreted_param_sorts() const override;
+    Datatype get_datatype() const override;
     bool compare(const Sort) const override;
     SortKind get_sort_kind() const override;
 

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -592,6 +592,25 @@ Sort CVC4Solver::make_sort(SortKind sk, const SortVec & sorts) const
   }
 }
 
+Sort CVC4Solver::make_sort(const Sort & uninterp_sort,
+                           const SortVec & sorts) const
+{
+  ::CVC4::api::Sort csort_con =
+      std::static_pointer_cast<CVC4Sort>(uninterp_sort)->sort;
+
+  size_t arity = sorts.size();
+  std::vector<::CVC4::api::Sort> csorts;
+  csorts.reserve(sorts.size());
+  ::CVC4::api::Sort csort;
+  for (uint32_t i = 0; i < arity; i++)
+  {
+    csort = std::static_pointer_cast<CVC4Sort>(sorts[i])->sort;
+    csorts.push_back(csort);
+  }
+
+  return std::make_shared<CVC4Sort>(csort_con.instantiate(csorts));
+}
+
 Term CVC4Solver::make_symbol(const std::string name, const Sort & sort)
 {
   // check that name is available

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -598,15 +598,14 @@ Sort CVC4Solver::make_sort(SortKind sk, const SortVec & sorts) const
   }
 }
 
-Sort CVC4Solver::make_sort(const Sort & uninterp_sort,
-                           const SortVec & sorts) const
+Sort CVC4Solver::make_sort(const Sort & sort_con, const SortVec & sorts) const
 {
   // TODO: enable this once getUninterpretedSortParamSorts is fixed in CVC4
   throw NotImplementedException(
       "CVC4 backend does not currently support sort constructors");
 
   ::CVC4::api::Sort csort_con =
-      std::static_pointer_cast<CVC4Sort>(uninterp_sort)->sort;
+      std::static_pointer_cast<CVC4Sort>(sort_con)->sort;
 
   size_t arity = sorts.size();
   std::vector<::CVC4::api::Sort> csorts;

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -433,6 +433,12 @@ Sort CVC4Solver::make_sort(const std::string name, uint64_t arity) const
 {
   try
   {
+    // TODO: enable this once getUninterpretedSortParamSorts is fixed in CVC4
+    if (arity)
+    {
+      throw NotImplementedException(
+          "CVC4 backend does not currently support sort constructors");
+    }
     return std::make_shared<CVC4Sort> (solver.declareSort(name, arity));
   }
   catch (::CVC4::api::CVC4ApiException & e)
@@ -595,6 +601,10 @@ Sort CVC4Solver::make_sort(SortKind sk, const SortVec & sorts) const
 Sort CVC4Solver::make_sort(const Sort & uninterp_sort,
                            const SortVec & sorts) const
 {
+  // TODO: enable this once getUninterpretedSortParamSorts is fixed in CVC4
+  throw NotImplementedException(
+      "CVC4 backend does not currently support sort constructors");
+
   ::CVC4::api::Sort csort_con =
       std::static_pointer_cast<CVC4Sort>(uninterp_sort)->sort;
 

--- a/cvc4/src/cvc4_sort.cpp
+++ b/cvc4/src/cvc4_sort.cpp
@@ -88,6 +88,9 @@ size_t CVC4Sort::get_arity() const
 
 SortVec CVC4Sort::get_uninterpreted_param_sorts() const
 {
+  // TODO: enable this once getUninterpretedSortParamSorts is fixed in CVC4
+  throw NotImplementedException(
+      "CVC4 backend does not currently support sort constructors");
   SortVec param_sorts;
   for (auto cs : sort.getUninterpretedSortParamSorts())
   {

--- a/cvc4/src/cvc4_sort.cpp
+++ b/cvc4/src/cvc4_sort.cpp
@@ -67,30 +67,13 @@ Sort CVC4Sort::get_codomain_sort() const
 
 std::string CVC4Sort::get_uninterpreted_name() const { return sort.toString(); }
 
-bool CVC4Sort::compare(const Sort s) const
-{
-  std::shared_ptr<CVC4Sort> cs = std::static_pointer_cast<CVC4Sort> (s);
-  return sort == cs->sort;
-}
-
-Datatype CVC4Sort::get_datatype() const
-{
-  try
-  {
-    return std::make_shared<CVC4Datatype> (sort.getDatatype());
-  } catch (::CVC4::api::CVC4ApiException & e)
-  {
-    throw InternalSolverException(e.what());
-  }
-};
-
 size_t CVC4Sort::get_arity() const
 {
   try
   {
     if (sort.isUninterpretedSort())
     {
-      return sort.getUninterpretedSortParamSorts().size();
+      return 0;
     }
     else
     {
@@ -102,6 +85,34 @@ size_t CVC4Sort::get_arity() const
     throw InternalSolverException(e.what());
   }
 }
+
+SortVec CVC4Sort::get_uninterpreted_param_sorts() const
+{
+  SortVec param_sorts;
+  for (auto cs : sort.getUninterpretedSortParamSorts())
+  {
+    param_sorts.push_back(std::make_shared<CVC4Sort>(cs));
+  }
+  return param_sorts;
+}
+
+bool CVC4Sort::compare(const Sort s) const
+{
+  std::shared_ptr<CVC4Sort> cs = std::static_pointer_cast<CVC4Sort>(s);
+  return sort == cs->sort;
+}
+
+Datatype CVC4Sort::get_datatype() const
+{
+  try
+  {
+    return std::make_shared<CVC4Datatype>(sort.getDatatype());
+  }
+  catch (::CVC4::api::CVC4ApiException & e)
+  {
+    throw InternalSolverException(e.what());
+  }
+};
 
 SortKind CVC4Sort::get_sort_kind() const
 {

--- a/cvc4/src/cvc4_sort.cpp
+++ b/cvc4/src/cvc4_sort.cpp
@@ -84,6 +84,24 @@ Datatype CVC4Sort::get_datatype() const
   }
 };
 
+size_t CVC4Sort::get_arity() const
+{
+  try
+  {
+    if (sort.isUninterpretedSort())
+    {
+      return sort.getUninterpretedSortParamSorts().size();
+    }
+    else
+    {
+      return sort.getSortConstructorArity();
+    }
+  }
+  catch (::CVC4::api::CVC4ApiException & e)
+  {
+    throw InternalSolverException(e.what());
+  }
+}
 
 SortKind CVC4Sort::get_sort_kind() const
 {
@@ -114,6 +132,10 @@ SortKind CVC4Sort::get_sort_kind() const
   else if (sort.isUninterpretedSort())
   {
     return UNINTERPRETED;
+  }
+  else if (sort.isSortConstructor())
+  {
+    return UNINTERPRETED_CONS;
   }
   else if (sort.isDatatype())
   {

--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -42,8 +42,7 @@ class LoggingSolver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(const SortKind sk, const SortVec & sorts) const override;
-  Sort make_sort(const Sort & uninterp_sort,
-                 const SortVec & sorts) const override;
+  Sort make_sort(const Sort & sort_con, const SortVec & sorts) const override;
   Sort make_sort(const DatatypeDecl & d) const override;
 
   DatatypeDecl make_datatype_decl(const std::string & s) override;

--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -42,6 +42,8 @@ class LoggingSolver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(const SortKind sk, const SortVec & sorts) const override;
+  Sort make_sort(const Sort & uninterp_sort,
+                 const SortVec & sorts) const override;
   Sort make_sort(const DatatypeDecl & d) const override;
 
   DatatypeDecl make_datatype_decl(const std::string & s) override;

--- a/include/logging_sort.h
+++ b/include/logging_sort.h
@@ -92,6 +92,12 @@ class LoggingSort : public AbsSort
         "get_datatype not implemented by generic LoggingSort");
   }
 
+  size_t get_arity() const override
+  {
+    throw NotImplementedException(
+        "get_arity not implemented by generic LoggingSort");
+  }
+
  protected:
   SortKind sk;
   Sort wrapped_sort;
@@ -155,6 +161,7 @@ class UninterpretedLoggingSort : public LoggingSort
   typedef LoggingSort super;
 
   std::string get_uninterpreted_name() const override;
+  size_t get_arity() const override;
 
  protected:
   std::string name;

--- a/include/logging_sort.h
+++ b/include/logging_sort.h
@@ -26,6 +26,10 @@ namespace smt {
 // Sort s is the underlying sort
 // all other sorts are LoggingSorts
 Sort make_uninterpreted_logging_sort(Sort s, std::string name, uint64_t arity);
+Sort make_uninterpreted_logging_sort(Sort s,
+                                     std::string name,
+                                     uint64_t arity,
+                                     const SortVec & sorts);
 Sort make_logging_sort(SortKind sk, Sort s);
 Sort make_logging_sort(SortKind sk, Sort s, uint64_t width);
 Sort make_logging_sort(SortKind sk, Sort s, Sort sort1);
@@ -86,16 +90,22 @@ class LoggingSort : public AbsSort
         "get_uninterpreted_name not implemented by generic LoggingSort");
   }
 
-  Datatype get_datatype() const override
-  {
-    throw NotImplementedException(
-        "get_datatype not implemented by generic LoggingSort");
-  }
-
   size_t get_arity() const override
   {
     throw NotImplementedException(
         "get_arity not implemented by generic LoggingSort");
+  }
+
+  SortVec get_uninterpreted_param_sorts() const override
+  {
+    throw NotImplementedException(
+        "get_uninterpreted_param_sorts not implemented by generic LoggingSort");
+  }
+
+  Datatype get_datatype() const override
+  {
+    throw NotImplementedException(
+        "get_datatype not implemented by generic LoggingSort");
   }
 
  protected:
@@ -156,16 +166,22 @@ class UninterpretedLoggingSort : public LoggingSort
 {
  public:
   UninterpretedLoggingSort(Sort s, std::string n, uint64_t a);
+  UninterpretedLoggingSort(Sort s,
+                           std::string n,
+                           uint64_t a,
+                           const SortVec & sorts);
   ~UninterpretedLoggingSort();
 
   typedef LoggingSort super;
 
   std::string get_uninterpreted_name() const override;
   size_t get_arity() const override;
+  SortVec get_uninterpreted_param_sorts() const override;
 
  protected:
   std::string name;
   uint64_t arity;
+  SortVec param_sorts;
 };
 
 }  // namespace smt

--- a/include/printing_solver.h
+++ b/include/printing_solver.h
@@ -81,8 +81,7 @@ class PrintingSolver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(const SortKind sk, const SortVec & sorts) const override;
-  Sort make_sort(const Sort & uninterp_sort,
-                 const SortVec & sorts) const override;
+  Sort make_sort(const Sort & sort_con, const SortVec & sorts) const override;
   Sort make_sort(const DatatypeDecl & d) const override;
   DatatypeDecl make_datatype_decl(const std::string & s) override;
   DatatypeConstructorDecl make_datatype_constructor_decl(

--- a/include/printing_solver.h
+++ b/include/printing_solver.h
@@ -81,6 +81,8 @@ class PrintingSolver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(const SortKind sk, const SortVec & sorts) const override;
+  Sort make_sort(const Sort & uninterp_sort,
+                 const SortVec & sorts) const override;
   Sort make_sort(const DatatypeDecl & d) const override;
   DatatypeDecl make_datatype_decl(const std::string & s) override;
   DatatypeConstructorDecl make_datatype_constructor_decl(

--- a/include/solver.h
+++ b/include/solver.h
@@ -174,6 +174,15 @@ class AbsSmtSolver
    */
   virtual Sort make_sort(const SortKind sk, const SortVec & sorts) const = 0;
 
+  /* Create an uninterpreted sort
+   * @param uninterp_sort a sort with SortKind UNINTERPRETED_CONS (must have
+   * nonzero arity)
+   * @param sorts a vector of sorts of size matching uninterp_sort->get_arity()
+   * @return a Sort object
+   */
+  virtual Sort make_sort(const Sort & uninterp_sort,
+                         const SortVec & sorts) const = 0;
+
   /* Create a datatype sort
    * @param d the Datatype Declaration
    * @return a Sort object

--- a/include/solver.h
+++ b/include/solver.h
@@ -175,12 +175,12 @@ class AbsSmtSolver
   virtual Sort make_sort(const SortKind sk, const SortVec & sorts) const = 0;
 
   /* Create an uninterpreted sort
-   * @param uninterp_sort a sort with SortKind UNINTERPRETED_CONS (must have
+   * @param sort_con a sort with SortKind UNINTERPRETED_CONS (must have
    * nonzero arity)
-   * @param sorts a vector of sorts of size matching uninterp_sort->get_arity()
+   * @param sorts a vector of sorts of size matching sort_con->get_arity()
    * @return a Sort object
    */
-  virtual Sort make_sort(const Sort & uninterp_sort,
+  virtual Sort make_sort(const Sort & sort_con,
                          const SortVec & sorts) const = 0;
 
   /* Create a datatype sort

--- a/include/sort.h
+++ b/include/sort.h
@@ -74,8 +74,9 @@ class AbsSort
   virtual std::vector<Sort> get_domain_sorts() const = 0;
   virtual Sort get_codomain_sort() const = 0;
   virtual std::string get_uninterpreted_name() const = 0;
-  virtual Datatype get_datatype() const = 0;
   virtual size_t get_arity() const = 0;
+  virtual std::vector<Sort> get_uninterpreted_param_sorts() const = 0;
+  virtual Datatype get_datatype() const = 0;
   virtual bool compare(const Sort sort) const = 0;
   virtual SortKind get_sort_kind() const = 0;
 };

--- a/include/sort.h
+++ b/include/sort.h
@@ -40,6 +40,9 @@ enum SortKind
   REAL,
   FUNCTION,
   UNINTERPRETED,
+  // an uninterpreted sort constructor (has non-zero arity and takes subsort
+  // arguments)
+  UNINTERPRETED_CONS,
   DATATYPE,
 
   /** IMPORTANT: This must stay at the bottom.
@@ -72,6 +75,7 @@ class AbsSort
   virtual Sort get_codomain_sort() const = 0;
   virtual std::string get_uninterpreted_name() const = 0;
   virtual Datatype get_datatype() const = 0;
+  virtual size_t get_arity() const = 0;
   virtual bool compare(const Sort sort) const = 0;
   virtual SortKind get_sort_kind() const = 0;
 };
@@ -103,7 +107,6 @@ template <>
 struct hash<smt::Sort>
 {
   size_t operator()(const smt::Sort & s) const { return s->hash(); }
-  };
-
+};
 }
 

--- a/include/term_translator.h
+++ b/include/term_translator.h
@@ -63,7 +63,7 @@ class TermTranslator
    *  @param the sort transfer
    *  @return a sort belonging to this solver
    */
-  Sort transfer_sort(const Sort & sort) const;
+  Sort transfer_sort(const Sort & sort);
 
   /** Transfers a term from the other solver to this solver
    *  @param term the term to transfer to the member variable solver
@@ -93,7 +93,7 @@ class TermTranslator
    *  called in this function)
    *  @return a term with the given value
    */
-  Term value_from_smt2(const std::string val, const Sort sort) const;
+  Term value_from_smt2(const std::string val, const Sort sort);
 
   /** identifies relevant casts to perform an operation
    *  assumes the operation is currently not well-sorted
@@ -135,6 +135,10 @@ class TermTranslator
   // it can still call non-const methods of the solver
   SmtSolver solver;  ///< solver to translate terms to
   UnorderedTermMap cache;
+  // map from uninterpreted sort names to the sort in the destination solver
+  // necessary because it needs to be the same exact uninterpreted sort
+  // cannot recreate it with the same name and get the same object back
+  std::unordered_map<std::string, Sort> uninterpreted_sorts;
 };
 }  // namespace smt
 

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -87,8 +87,7 @@ class MsatSolver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(SortKind sk, const SortVec & sorts) const override;
-  Sort make_sort(const Sort & uninterp_sort,
-                 const SortVec & sorts) const override;
+  Sort make_sort(const Sort & sort_con, const SortVec & sorts) const override;
 
   Sort make_sort(const DatatypeDecl & d) const override;
 

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -87,6 +87,8 @@ class MsatSolver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(SortKind sk, const SortVec & sorts) const override;
+  Sort make_sort(const Sort & uninterp_sort,
+                 const SortVec & sorts) const override;
 
   Sort make_sort(const DatatypeDecl & d) const override;
 

--- a/msat/include/msat_sort.h
+++ b/msat/include/msat_sort.h
@@ -38,6 +38,7 @@ class MsatSort : public AbsSort
   Sort get_codomain_sort() const override;
   std::string get_uninterpreted_name() const override;
   Datatype get_datatype() const override;
+  size_t get_arity() const override;
   bool compare(const Sort) const override;
   SortKind get_sort_kind() const override;
 

--- a/msat/include/msat_sort.h
+++ b/msat/include/msat_sort.h
@@ -37,8 +37,9 @@ class MsatSort : public AbsSort
   SortVec get_domain_sorts() const override;
   Sort get_codomain_sort() const override;
   std::string get_uninterpreted_name() const override;
-  Datatype get_datatype() const override;
   size_t get_arity() const override;
+  SortVec get_uninterpreted_param_sorts() const override;
+  Datatype get_datatype() const override;
   bool compare(const Sort) const override;
   SortKind get_sort_kind() const override;
 

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -484,8 +484,7 @@ Sort MsatSolver::make_sort(SortKind sk, const SortVec & sorts) const
   }
 }
 
-Sort MsatSolver::make_sort(const Sort & uninterp_sort,
-                           const SortVec & sorts) const
+Sort MsatSolver::make_sort(const Sort & sort_con, const SortVec & sorts) const
 {
   throw NotImplementedException(
       "MathSAT does not support uninterpreted sort constructors");

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -484,6 +484,12 @@ Sort MsatSolver::make_sort(SortKind sk, const SortVec & sorts) const
   }
 }
 
+Sort MsatSolver::make_sort(const Sort & uninterp_sort,
+                           const SortVec & sorts) const
+{
+  throw NotImplementedException(
+      "MathSAT does not support uninterpreted sort constructors");
+}
 
 Sort MsatSolver::make_sort(const DatatypeDecl & d) const {
   throw NotImplementedException("MsatSolver::make_sort");

--- a/msat/src/msat_sort.cpp
+++ b/msat/src/msat_sort.cpp
@@ -120,6 +120,11 @@ Datatype MsatSort::get_datatype() const {
   throw NotImplementedException("get_datatype");
 };
 
+size_t MsatSort::get_arity() const
+{
+  // MathSAT does not support uninterpreted sorts with non-zero arity
+  return 0;
+}
 
 bool MsatSort::compare(const Sort s) const
 {

--- a/msat/src/msat_sort.cpp
+++ b/msat/src/msat_sort.cpp
@@ -116,15 +116,22 @@ string MsatSort::get_uninterpreted_name() const
   return res;
 }
 
-Datatype MsatSort::get_datatype() const {
-  throw NotImplementedException("get_datatype");
-};
-
 size_t MsatSort::get_arity() const
 {
   // MathSAT does not support uninterpreted sorts with non-zero arity
   return 0;
 }
+
+SortVec MsatSort::get_uninterpreted_param_sorts() const
+{
+  throw NotImplementedException(
+      "MathSAT does not support uninterpreted sort constructors");
+}
+
+Datatype MsatSort::get_datatype() const
+{
+  throw NotImplementedException("get_datatype");
+};
 
 bool MsatSort::compare(const Sort s) const
 {

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -112,6 +112,26 @@ Sort LoggingSolver::make_sort(SortKind sk, const SortVec & sorts) const
   return make_logging_sort(sk, sort, sorts);
 }
 
+Sort LoggingSolver::make_sort(const Sort & uninterp_sort,
+                              const SortVec & sorts) const
+{
+  Sort sub_uninterp_sort =
+      static_pointer_cast<LoggingSort>(uninterp_sort)->wrapped_sort;
+
+  // convert to sorts stored by LoggingSorts
+  SortVec sub_sorts;
+  for (auto s : sorts)
+  {
+    sub_sorts.push_back(static_pointer_cast<LoggingSort>(s)->wrapped_sort);
+  }
+
+  Sort ressort = wrapped_solver->make_sort(sub_uninterp_sort, sub_sorts);
+  return make_uninterpreted_logging_sort(
+      ressort,
+      uninterp_sort->get_uninterpreted_name(),
+      0,  // has zero arity after applied
+      sorts);
+}
 
 Sort LoggingSolver::make_sort(const DatatypeDecl & d) const {
   throw NotImplementedException("LoggingSolver::make_sort");

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -112,11 +112,10 @@ Sort LoggingSolver::make_sort(SortKind sk, const SortVec & sorts) const
   return make_logging_sort(sk, sort, sorts);
 }
 
-Sort LoggingSolver::make_sort(const Sort & uninterp_sort,
+Sort LoggingSolver::make_sort(const Sort & sort_con,
                               const SortVec & sorts) const
 {
-  Sort sub_uninterp_sort =
-      static_pointer_cast<LoggingSort>(uninterp_sort)->wrapped_sort;
+  Sort sub_sort_con = static_pointer_cast<LoggingSort>(sort_con)->wrapped_sort;
 
   // convert to sorts stored by LoggingSorts
   SortVec sub_sorts;
@@ -125,12 +124,11 @@ Sort LoggingSolver::make_sort(const Sort & uninterp_sort,
     sub_sorts.push_back(static_pointer_cast<LoggingSort>(s)->wrapped_sort);
   }
 
-  Sort ressort = wrapped_solver->make_sort(sub_uninterp_sort, sub_sorts);
-  return make_uninterpreted_logging_sort(
-      ressort,
-      uninterp_sort->get_uninterpreted_name(),
-      0,  // has zero arity after applied
-      sorts);
+  Sort ressort = wrapped_solver->make_sort(sub_sort_con, sub_sorts);
+  return make_uninterpreted_logging_sort(ressort,
+                                         sort_con->get_uninterpreted_name(),
+                                         0,  // has zero arity after applied
+                                         sorts);
 }
 
 Sort LoggingSolver::make_sort(const DatatypeDecl & d) const {

--- a/src/logging_sort.cpp
+++ b/src/logging_sort.cpp
@@ -228,7 +228,9 @@ Sort FunctionLoggingSort::get_codomain_sort() const { return codomain_sort; }
 // UninterpretedLoggingSort
 
 UninterpretedLoggingSort::UninterpretedLoggingSort(Sort s, string n, uint64_t a)
-    : super(UNINTERPRETED, s), name(n), arity(a)
+    // non-zero arity means it's a sort constructor
+    // otherwise it's just an uninterpreted sort
+    : super(a ? UNINTERPRETED_CONS : UNINTERPRETED, s), name(n), arity(a)
 {
 }
 
@@ -238,5 +240,7 @@ std::string UninterpretedLoggingSort::get_uninterpreted_name() const
 {
   return name;
 }
+
+size_t UninterpretedLoggingSort::get_arity() const { return arity; }
 
 }  // namespace smt

--- a/src/logging_sort.cpp
+++ b/src/logging_sort.cpp
@@ -27,6 +27,20 @@ Sort make_uninterpreted_logging_sort(Sort s, string name, uint64_t arity)
   return std::make_shared<UninterpretedLoggingSort>(s, name, arity);
 }
 
+Sort make_uninterpreted_logging_sort(Sort s,
+                                     string name,
+                                     uint64_t arity,
+                                     const SortVec & sorts)
+{
+  if (sorts.size() != arity)
+  {
+    throw IncorrectUsageException(
+        "Number of uninterpreted param sorts must match sort constructor "
+        "arity");
+  }
+  return std::make_shared<UninterpretedLoggingSort>(s, name, arity, sorts);
+}
+
 Sort make_logging_sort(SortKind sk, Sort s)
 {
   if (sk != BOOL && sk != INT && sk != REAL)
@@ -234,6 +248,14 @@ UninterpretedLoggingSort::UninterpretedLoggingSort(Sort s, string n, uint64_t a)
 {
 }
 
+UninterpretedLoggingSort::UninterpretedLoggingSort(Sort s,
+                                                   string n,
+                                                   uint64_t a,
+                                                   const SortVec & sorts)
+    : super(UNINTERPRETED, s), name(n), arity(a), param_sorts(sorts)
+{
+}
+
 UninterpretedLoggingSort::~UninterpretedLoggingSort() {}
 
 std::string UninterpretedLoggingSort::get_uninterpreted_name() const
@@ -242,5 +264,10 @@ std::string UninterpretedLoggingSort::get_uninterpreted_name() const
 }
 
 size_t UninterpretedLoggingSort::get_arity() const { return arity; }
+
+SortVec UninterpretedLoggingSort::get_uninterpreted_param_sorts() const
+{
+  return param_sorts;
+}
 
 }  // namespace smt

--- a/src/printing_solver.cpp
+++ b/src/printing_solver.cpp
@@ -91,10 +91,10 @@ Sort PrintingSolver::make_sort(SortKind sk, const SortVec & sorts) const
   return wrapped_solver->make_sort(sk, sorts);
 }
 
-Sort PrintingSolver::make_sort(const Sort & uninterp_sort,
+Sort PrintingSolver::make_sort(const Sort & sort_con,
                                const SortVec & sorts) const
 {
-  return wrapped_solver->make_sort(uninterp_sort, sorts);
+  return wrapped_solver->make_sort(sort_con, sorts);
 }
 
 Sort PrintingSolver::make_sort(const DatatypeDecl & d) const {

--- a/src/printing_solver.cpp
+++ b/src/printing_solver.cpp
@@ -91,6 +91,11 @@ Sort PrintingSolver::make_sort(SortKind sk, const SortVec & sorts) const
   return wrapped_solver->make_sort(sk, sorts);
 }
 
+Sort PrintingSolver::make_sort(const Sort & uninterp_sort,
+                               const SortVec & sorts) const
+{
+  return wrapped_solver->make_sort(uninterp_sort, sorts);
+}
 
 Sort PrintingSolver::make_sort(const DatatypeDecl & d) const {
   throw NotImplementedException("PrintingSolver::make_sort");

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -31,7 +31,8 @@ const std::unordered_map<SortKind, std::string> sortkind2str(
       { REAL, "REAL" },
       { FUNCTION, "FUNCTION" },
       { UNINTERPRETED, "UNINTERPRETED" },
-      { DATATYPE, "DATATYPE"} });
+      { UNINTERPRETED_CONS, "UNINTERPRETED_CONS" },
+      { DATATYPE, "DATATYPE" } });
 
 std::string to_string(SortKind sk)
 {

--- a/src/term_translator.cpp
+++ b/src/term_translator.cpp
@@ -98,9 +98,9 @@ Sort TermTranslator::transfer_sort(const Sort & sort)
     }
     else
     {
-      Sort uninterp_sort = solver->make_sort(name, 0);
-      uninterpreted_sorts[name] = uninterp_sort;
-      return uninterp_sort;
+      Sort sort_con = solver->make_sort(name, 0);
+      uninterpreted_sorts[name] = sort_con;
+      return sort_con;
     }
   }
   else

--- a/tests/unit/unit-sort.cpp
+++ b/tests/unit/unit-sort.cpp
@@ -93,6 +93,44 @@ TEST_P(UnitSortTests, SortParams)
   // not every solver supports querying function types for domain/codomain yet
 }
 
+TEST_P(UnitSortTests, UninterpretedSort)
+{
+  Sort uninterp_sort;
+  try
+  {
+    uninterp_sort = s->make_sort("declared-sort", 0);
+  }
+  catch (SmtException & e)
+  {
+    // if not supported, that's fine.
+    std::cout << "got exception when declaring sort: " << e.what() << std::endl;
+    return;
+  }
+
+  ASSERT_TRUE(uninterp_sort);
+  EXPECT_EQ(uninterp_sort->get_sort_kind(), UNINTERPRETED);
+  EXPECT_EQ(uninterp_sort->get_arity(), 0);
+
+  // Now try non-zero arity (not supported by very many solvers)
+  Sort sort_cons;
+  try
+  {
+    sort_cons = s->make_sort("sort-con", 4);
+  }
+  catch (SmtException & e)
+  {
+    // if not supported, that's fine.
+    std::cout << "got exception when declaring nonzero arity sort: " << e.what()
+              << std::endl;
+    return;
+  }
+
+  ASSERT_TRUE(sort_cons);
+  // Expecting an uninterpreted constructor sort
+  EXPECT_EQ(sort_cons->get_sort_kind(), UNINTERPRETED_CONS);
+  EXPECT_EQ(sort_cons->get_arity(), 4);
+}
+
 TEST_P(UnitSortArithTests, SameSortDiffObj)
 {
   Sort intsort_2 = s->make_sort(INT);

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -81,8 +81,7 @@ class Yices2Solver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(SortKind sk, const SortVec & sorts) const override;
-  Sort make_sort(const Sort & uninterp_sort,
-                 const SortVec & sorts) const override;
+  Sort make_sort(const Sort & sort_con, const SortVec & sorts) const override;
   Sort make_sort(const DatatypeDecl & d) const override;
 
   DatatypeDecl make_datatype_decl(const std::string & s) override;

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -81,7 +81,8 @@ class Yices2Solver : public AbsSmtSolver
                  const Sort & sort2,
                  const Sort & sort3) const override;
   Sort make_sort(SortKind sk, const SortVec & sorts) const override;
-
+  Sort make_sort(const Sort & uninterp_sort,
+                 const SortVec & sorts) const override;
   Sort make_sort(const DatatypeDecl & d) const override;
 
   DatatypeDecl make_datatype_decl(const std::string & s) override;

--- a/yices2/include/yices2_sort.h
+++ b/yices2/include/yices2_sort.h
@@ -45,6 +45,7 @@ class Yices2Sort : public AbsSort
   Sort get_codomain_sort() const override;
   std::string get_uninterpreted_name() const override;
   Datatype get_datatype() const override;
+  size_t get_arity() const override;
   bool compare(const Sort s) const override;
   SortKind get_sort_kind() const override;
   type_t get_ytype() { return type; };

--- a/yices2/include/yices2_sort.h
+++ b/yices2/include/yices2_sort.h
@@ -44,8 +44,9 @@ class Yices2Sort : public AbsSort
   SortVec get_domain_sorts() const override;
   Sort get_codomain_sort() const override;
   std::string get_uninterpreted_name() const override;
-  Datatype get_datatype() const override;
   size_t get_arity() const override;
+  SortVec get_uninterpreted_param_sorts() const override;
+  Datatype get_datatype() const override;
   bool compare(const Sort s) const override;
   SortKind get_sort_kind() const override;
   type_t get_ytype() { return type; };

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -630,8 +630,7 @@ Sort Yices2Solver::make_sort(SortKind sk, const SortVec & sorts) const
   return std::make_shared<Yices2Sort> (y_sort, true);
 }
 
-Sort Yices2Solver::make_sort(const Sort & uninterp_sort,
-                             const SortVec & sorts) const
+Sort Yices2Solver::make_sort(const Sort & sort_con, const SortVec & sorts) const
 {
   throw NotImplementedException(
       "Yices2 does not support uninterpreted sort constructors");

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -630,6 +630,13 @@ Sort Yices2Solver::make_sort(SortKind sk, const SortVec & sorts) const
   return std::make_shared<Yices2Sort> (y_sort, true);
 }
 
+Sort Yices2Solver::make_sort(const Sort & uninterp_sort,
+                             const SortVec & sorts) const
+{
+  throw NotImplementedException(
+      "Yices2 does not support uninterpreted sort constructors");
+}
+
 Term Yices2Solver::make_symbol(const std::string name, const Sort & sort)
 {
   shared_ptr<Yices2Sort> ysort = static_pointer_cast<Yices2Sort>(sort);

--- a/yices2/src/yices2_sort.cpp
+++ b/yices2/src/yices2_sort.cpp
@@ -118,6 +118,11 @@ Datatype Yices2Sort::get_datatype() const {
   throw NotImplementedException("get_datatype");
 };
 
+size_t Yices2Sort::get_arity() const
+{
+  // yices2 does not support uninterpreted sorts with non-zero arity
+  return 0;
+}
 
 bool Yices2Sort::compare(const Sort s) const
 {
@@ -155,6 +160,10 @@ SortKind Yices2Sort::get_sort_kind() const
     {
       return FUNCTION;
     }
+  }
+  else if (yices_type_is_uninterpreted(type))
+  {
+    return UNINTERPRETED;
   }
   else
   {

--- a/yices2/src/yices2_sort.cpp
+++ b/yices2/src/yices2_sort.cpp
@@ -113,16 +113,22 @@ string Yices2Sort::get_uninterpreted_name() const
       "get_uninterpreted_name not implemented for Yices2Sort");
 }
 
-
-Datatype Yices2Sort::get_datatype() const {
-  throw NotImplementedException("get_datatype");
-};
-
 size_t Yices2Sort::get_arity() const
 {
   // yices2 does not support uninterpreted sorts with non-zero arity
   return 0;
 }
+
+SortVec Yices2Sort::get_uninterpreted_param_sorts() const
+{
+  throw NotImplementedException(
+      "Yices2 does not support uninterpreted sort constructors");
+}
+
+Datatype Yices2Sort::get_datatype() const
+{
+  throw NotImplementedException("get_datatype");
+};
 
 bool Yices2Sort::compare(const Sort s) const
 {


### PR DESCRIPTION
Adds a `get_arity` method to sorts for obtaining the arity of an uninterpreted sort. It also adds a new `SortKind` called `UNINTERPRETED_CONS` for an uninterpreted sort constructor. This is to distinguish between a sort declared with non-zero arity before (`UNINTERPRETED_CONS`) and after (`UNINTERPRETED`) it has been applied to subsort arguments.