### PR TITLE
Use `-undefined dynamic_lookup` when `Py_ENABLE_SHARED` is 0

### DIFF
--- a/cmake/FindPythonLibs.cmake
+++ b/cmake/FindPythonLibs.cmake
@@ -268,6 +268,7 @@ function(python_extension_module _target)
     # linux doesn't need to link against python libraries
     if (APPLE)
         # determine linkage of python
+        # see https://github.com/upscale-project/pono/issues/92 for context
         execute_process(
             COMMAND
             ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('Py_ENABLE_SHARED'))"
@@ -277,8 +278,6 @@ function(python_extension_module _target)
         if(Py_ENABLE_SHARED)
           target_link_libraries_with_dynamic_lookup(${_target} ${PYTHON_LIBRARIES})
         else()
-          # can't link against libpython, 
-          # see https://github.com/upscale-project/pono/issues/92 for context
           set_target_properties(${_target} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
         endif()
     endif()

--- a/cmake/FindPythonLibs.cmake
+++ b/cmake/FindPythonLibs.cmake
@@ -265,9 +265,20 @@ function(python_extension_module _target)
       set_target_properties(${_target} PROPERTIES SUFFIX ".pyd")
     endif()
 
+    # linux doesn't need to link against python libraries
     if (APPLE)
-        # linux doesn't need to link against python libraries
-        target_link_libraries_with_dynamic_lookup(${_target} ${PYTHON_LIBRARIES})
+        # determine linkage of python
+        execute_process(
+            COMMAND
+            ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_config_var('Py_ENABLE_SHARED'))"
+            OUTPUT_VARIABLE Py_ENABLE_SHARED
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if(Py_ENABLE_SHARED)
+          target_link_libraries_with_dynamic_lookup(${_target} ${PYTHON_LIBRARIES})
+        else()
+          set_target_properties(${_target} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+        endif()
     endif()
   endif()
 endfunction()

--- a/cmake/FindPythonLibs.cmake
+++ b/cmake/FindPythonLibs.cmake
@@ -277,6 +277,8 @@ function(python_extension_module _target)
         if(Py_ENABLE_SHARED)
           target_link_libraries_with_dynamic_lookup(${_target} ${PYTHON_LIBRARIES})
         else()
+          # can't link against libpython, 
+          # see https://github.com/upscale-project/pono/issues/92 for context
           set_target_properties(${_target} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
         endif()
     endif()


### PR DESCRIPTION
Fixes https://github.com/upscale-project/pono/issues/92

It seems that the `target_link_libraries_with_dynamic_lookup` logic
doesn't properly discover this requirement on my version of macOS
(10.15.6) and conda (conda 4.8.3).

This uses the cmake command from
https://github.com/conda-forge/python-feedstock/issues/272 to read
Py_ENABLE_SHARED.  If this config var isn't set, we use `-undefined
dynamic_lookup` rather than linking the python library directly