### PR TITLE
Parameterize tests by configurations, not enums

### DIFF
--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -97,23 +97,6 @@ class LoggingSolver : public AbsSmtSolver
   // after a call to get_unsat_core
   std::unique_ptr<UnorderedTermMap> assumption_cache;
 
-  /** Maps the wrapped_solver's SolverEnum to the logging
-   *  solver version
-   *  throws an exception if the SolverEnum is already
-   *  a logging solver (there's no reason to nest
-   *  LoggingSolvers)
-   */
-  static SolverEnum process_solver_enum(SolverEnum se)
-  {
-    if (is_logging_solver_enum(se))
-    {
-      throw IncorrectUsageException(
-          std::string("Got a logging solver as the underlying solver in ")
-          + "LoggingSolver construction. There's no reason to "
-          + "next LoggingSolvers");
-    }
-    return get_logging_solver_enum(se);
-  }
 };
 
 }  // namespace smt

--- a/include/solver_enums.h
+++ b/include/solver_enums.h
@@ -25,11 +25,6 @@ enum SolverEnum
   CVC4,
   MSAT,
   YICES2,
-  // have separate enum for solver wrapped by LoggingSolver with Shadow DAG
-  BTOR_LOGGING,
-  CVC4_LOGGING,
-  MSAT_LOGGING,
-  YICES2_LOGGING,
   // interpolating solvers -- note these cannot be logging solvers
   // because the solver takes the initiative in creating the interpolant
   // so there's no way to keep a DAG at the smt-switch level
@@ -72,24 +67,11 @@ enum SolverAttribute
   // and enums_imp.pxi
 };
 
-/** Returns true iff the SolverEnum corresponds to a LoggingSolver
- *  @param se the solver enum to check
- *  @return true iff the se is a *_LOGGING enum
- */
-bool is_logging_solver_enum(SolverEnum se);
-
 /** Returns true iff the SolverEnum corresponds to an Interpolator
  *  @param se the solver enum to check
  *  @return true iff the se is a *_INTERPOLATOR enum
  */
 bool is_interpolator_solver_enum(SolverEnum se);
-
-/** Maps a non-logging solver enum to the logging version
- *  e.g. BTOR -> BTOR_LOGGING
- *  @param se a non-logging solver enum to map
- *  @return the logging solver version of this enum
- */
-SolverEnum get_logging_solver_enum(SolverEnum se);
 
 bool solver_has_attribute(SolverEnum se, SolverAttribute sa);
 

--- a/python/enums_dec.pxi
+++ b/python/enums_dec.pxi
@@ -31,10 +31,6 @@ cdef extern from "solver_enums.h" namespace "smt":
     cdef c_SolverEnum c_CVC4 "smt::CVC4"
     cdef c_SolverEnum c_MSAT "smt::MSAT"
     cdef c_SolverEnum c_YICES2 "smt::YICES2"
-    cdef c_SolverEnum c_BTOR_LOGGING "smt::BTOR_LOGGING"
-    cdef c_SolverEnum c_CVC4_LOGGING "smt::CVC4_LOGGING"
-    cdef c_SolverEnum c_MSAT_LOGGING "smt::MSAT_LOGGING"
-    cdef c_SolverEnum c_YICES2_LOGGING "smt::YICES2_LOGGING"
     cdef c_SolverEnum c_MSAT_INTERPOLATOR "smt::MSAT_INTERPOLATOR"
     cdef c_SolverEnum c_CVC4_INTERPOLATOR "smt::CVC4_INTERPOLATOR"
 

--- a/python/enums_imp.pxi
+++ b/python/enums_imp.pxi
@@ -103,22 +103,6 @@ cdef SolverEnum YICES2 = SolverEnum()
 YICES2.se = c_YICES2
 setattr(solverenums, 'YICES2', YICES2)
 
-cdef SolverEnum BTOR_LOGGING = SolverEnum()
-BTOR_LOGGING.se = c_BTOR_LOGGING
-setattr(solverenums, 'BTOR_LOGGING', BTOR)
-
-cdef SolverEnum CVC4_LOGGING = SolverEnum()
-CVC4_LOGGING.se = c_CVC4_LOGGING
-setattr(solverenums, 'CVC4_LOGGING', CVC4_LOGGING)
-
-cdef SolverEnum MSAT_LOGGING = SolverEnum()
-MSAT_LOGGING.se = c_MSAT_LOGGING
-setattr(solverenums, 'MSAT_LOGGING', MSAT_LOGGING)
-
-cdef SolverEnum YICES2_LOGGING = SolverEnum()
-YICES2_LOGGING.se = c_YICES2_LOGGING
-setattr(solverenums, 'YICES2_LOGGING', YICES2_LOGGING)
-
 cdef SolverEnum MSAT_INTERPOLATOR = SolverEnum()
 MSAT_INTERPOLATOR.se = c_MSAT_INTERPOLATOR
 setattr(solverenums, "MSAT_INTERPOLATOR", MSAT_INTERPOLATOR)

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -41,7 +41,7 @@ const unordered_set<SortKind> supported_sortkinds_for_get_value(
 // implementations
 
 LoggingSolver::LoggingSolver(SmtSolver s)
-    : AbsSmtSolver(process_solver_enum(s->get_solver_enum())),
+    : AbsSmtSolver(s->get_solver_enum()),
       wrapped_solver(s),
       hashtable(new TermHashTable()),
       assumption_cache(new UnorderedTermMap())

--- a/src/solver_enums.cpp
+++ b/src/solver_enums.cpp
@@ -29,25 +29,17 @@ const unordered_map<SolverEnum, unordered_set<SolverAttribute>>
     solver_attributes({
         { BTOR,
           { TERMITER,
+            LOGGING,
             ARRAY_MODELS,
             CONSTARR,
             UNSAT_CORE,
             QUANTIFIERS,
             BOOL_BV1_ALIASING } },
 
-        { BTOR_LOGGING,
-          { LOGGING,
-            TERMITER,
-            ARRAY_MODELS,
-            ARRAY_FUN_BOOLS,
-            CONSTARR,
-            FULL_TRANSFER,
-            UNSAT_CORE,
-            QUANTIFIERS } },
-
         { CVC4,
           {
               TERMITER,
+              LOGGING,
               THEORY_INT,
               THEORY_REAL,
               ARRAY_MODELS,
@@ -59,31 +51,9 @@ const unordered_map<SolverEnum, unordered_set<SolverAttribute>>
               QUANTIFIERS
           } },
 
-        { CVC4_LOGGING,
-          { LOGGING,
-            TERMITER,
-            THEORY_INT,
-            THEORY_REAL,
-            ARRAY_MODELS,
-            ARRAY_FUN_BOOLS,
-            CONSTARR,
-            FULL_TRANSFER,
-            UNSAT_CORE,
-            QUANTIFIERS } },
-
         { MSAT,
           { TERMITER,
-            THEORY_INT,
-            THEORY_REAL,
-            ARRAY_MODELS,
-            CONSTARR,
-            FULL_TRANSFER,
-            UNSAT_CORE,
-            QUANTIFIERS } },
-
-        { MSAT_LOGGING,
-          { LOGGING,
-            TERMITER,
+            LOGGING,
             THEORY_INT,
             THEORY_REAL,
             ARRAY_MODELS,
@@ -96,55 +66,16 @@ const unordered_map<SolverEnum, unordered_set<SolverAttribute>>
         //       but something funky happens with testing
         //       has something to do with the context and yices_init
         //       look into this more and re-enable it
-        { YICES2, { THEORY_INT, THEORY_REAL, ARRAY_FUN_BOOLS } },
-
-        { YICES2_LOGGING,
-          { LOGGING,
-            TERMITER,
-            THEORY_INT,
-            THEORY_REAL,
-            ARRAY_FUN_BOOLS,
-            FULL_TRANSFER,
-            UNSAT_CORE } },
+        { YICES2, { LOGGING, THEORY_INT, THEORY_REAL, ARRAY_FUN_BOOLS } },
 
     });
-
-const unordered_set<SolverEnum> logging_solver_enums(
-    { BTOR_LOGGING, CVC4_LOGGING, MSAT_LOGGING, YICES2_LOGGING });
-const unordered_map<SolverEnum, SolverEnum> to_logging_solver_enum(
-    { { BTOR, BTOR_LOGGING },
-      { CVC4, CVC4_LOGGING },
-      { MSAT, MSAT_LOGGING },
-      { YICES2, YICES2_LOGGING } });
 
 const unordered_set<SolverEnum> interpolator_solver_enums(
     { MSAT_INTERPOLATOR, CVC4_INTERPOLATOR });
 
-bool is_logging_solver_enum(SolverEnum se)
-{
-  return logging_solver_enums.find(se) != logging_solver_enums.end();
-}
-
 bool is_interpolator_solver_enum(SolverEnum se)
 {
   return interpolator_solver_enums.find(se) != interpolator_solver_enums.end();
-}
-
-SolverEnum get_logging_solver_enum(SolverEnum se)
-{
-  if (is_logging_solver_enum(se))
-  {
-    throw IncorrectUsageException("Expecting non-logging solver enum but got "
-                                  + to_string(se));
-  }
-  else if (to_logging_solver_enum.find(se) == to_logging_solver_enum.end())
-  {
-    throw NotImplementedException(
-        "Don't have a mapping from solver enum to logging version for "
-        + to_string(se));
-  }
-
-  return to_logging_solver_enum.at(se);
 }
 
 bool solver_has_attribute(SolverEnum se, SolverAttribute sa)
@@ -171,10 +102,6 @@ std::ostream & operator<<(std::ostream & o, SolverEnum e)
     case CVC4: o << "CVC4"; break;
     case MSAT: o << "MSAT"; break;
     case YICES2: o << "YICES2"; break;
-    case BTOR_LOGGING: o << "BTOR_LOGGING"; break;
-    case CVC4_LOGGING: o << "CVC4_LOGGING"; break;
-    case MSAT_LOGGING: o << "MSAT_LOGGING"; break;
-    case YICES2_LOGGING: o << "YICES2_LOGGING"; break;
     case MSAT_INTERPOLATOR: o << "MSAT_INTERPOLATOR"; break;
     case CVC4_INTERPOLATOR: o << "CVC4_INTERPOLATOR"; break;
     default:

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -160,8 +160,6 @@ std::vector<SolverConfiguration> available_interpolator_configurations() {
     SolverConfiguration sc;
     sc.solver_enum = e;
     sc.is_logging_solver = false;
-    //TODO do we ignore logging_interpolator? 
-    // seems like this is the case currently on master?
     result.push_back(sc);
   }
   return result;

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -124,8 +124,8 @@ SmtSolver create_solver(SolverEnum se)
 
 SmtSolver create_solver(SolverConfiguration sc)
 {
-  SolverEnum se = sc.get_solver_enum();
-  bool logging = sc.get_is_logging_solver();
+  SolverEnum se = sc.solver_enum;
+  bool logging = sc.is_logging_solver;
   switch (se)
   {
 #if BUILD_BTOR
@@ -189,19 +189,18 @@ SmtSolver create_interpolating_solver(SolverEnum se)
 
 std::vector<SolverEnum> available_solver_enums() { return solver_enums; }
 
-SolverConfiguration::SolverConfiguration(SolverEnum e, bool logging)
-    : solver_enum(e), is_logging_solver(logging)
-{
-}
-
 std::vector<SolverConfiguration> available_solver_configurations()
 {
   std::vector<SolverConfiguration> configs;
   std::vector<SolverEnum> enums = available_no_logging_solver_enums();
   for (SolverEnum e : enums)
   {
-    configs.push_back(SolverConfiguration(e, true));
-    configs.push_back(SolverConfiguration(e, false));
+    SolverConfiguration sc;
+    sc.solver_enum = e;
+    sc.is_logging_solver = true;
+    configs.push_back(sc);
+    sc.is_logging_solver = false;
+    configs.push_back(sc);
   }
   return configs;
 }

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -42,19 +42,19 @@ namespace smt_tests {
 // list of regular (non-interpolator) solver enums
 const std::vector<SolverEnum> solver_enums({
 #if BUILD_BTOR
-  BTOR
+  BTOR,
 #endif
 
 #if BUILD_CVC4
-      CVC4
+      CVC4,
 #endif
 
 #if BUILD_MSAT
-      MSAT
+      MSAT,
 #endif
 
 #if BUILD_YICES2
-      YICES2
+      YICES2,
 #endif
 });
 

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -33,6 +33,8 @@
 #include "yices2_factory.h"
 #endif
 
+#include <algorithm>
+
 using namespace smt;
 
 namespace smt_tests {
@@ -205,6 +207,18 @@ std::vector<SolverConfiguration> available_solver_configurations()
   return configs;
 }
 
+std::vector<SolverConfiguration> available_no_logging_solver_configurations() {
+  std::vector<SolverEnum> enums = available_no_logging_solver_enums();
+  std::vector<SolverConfiguration> result;
+  for (SolverEnum e : enums) {
+    SolverConfiguration sc;
+    sc.solver_enum = e;
+    sc.is_logging_solver = false;
+    result.push_back(sc);
+  }
+  return result;
+}
+
 // collect all the available non-logging solvers
 std::vector<SolverEnum> available_no_logging_solver_enums()
 {
@@ -279,5 +293,30 @@ std::vector<SolverEnum> filter_solver_enums(
   return filtered_enums;
 }
 
+std::vector<SolverConfiguration> filter_solver_configurations(
+    const std::unordered_set<SolverAttribute> attributes)
+{
+  // first get the enums
+  std::vector<SolverEnum> filtered_enums = filter_solver_enums(attributes);
+  // remove all the logging enums
+  std::vector<SolverEnum> logging_enums = available_logging_solver_enums();
+  for (SolverEnum e : filtered_enums) {
+    if (std::find(logging_enums.begin(), logging_enums.end(), e) != logging_enums.end()) {
+      filtered_enums.erase(std::find(filtered_enums.begin(), filtered_enums.end(), e));
+    }
+  }
+  
+  // compute result
+  std::vector<SolverConfiguration> result;
+  for (SolverEnum e : filtered_enums) {
+    SolverConfiguration sc;
+    sc.solver_enum = e;
+    sc.is_logging_solver = false;
+    result.push_back(sc);
+    sc.is_logging_solver = true;
+    result.push_back(sc);
+  }
+  return result;
+}
 
 }  // namespace smt_tests

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -164,6 +164,11 @@ SmtSolver create_solver(SolverConfiguration sc)
   }
 }
 
+SmtSolver create_interpolating_solver(SolverConfiguration sc) {
+  SolverEnum se = sc.solver_enum;
+  return create_interpolating_solver(se);
+}
+
 SmtSolver create_interpolating_solver(SolverEnum se)
 {
   switch (se)
@@ -262,6 +267,20 @@ std::vector<SolverEnum> available_interpolator_enums() {
   result.push_back(CVC4_INTERPOLATOR);
 #endif  
 
+  return result;
+}
+
+std::vector<SolverConfiguration> available_interpolator_configurations() { 
+  std::vector<SolverEnum> enums = available_interpolator_enums();
+  std::vector<SolverConfiguration> result;
+  for (SolverEnum e : enums) {
+    SolverConfiguration sc;
+    sc.solver_enum = e;
+    sc.is_logging_solver = false;
+    //TODO do we ignore logging_interpolator? 
+    // seems like this is the case currently on master?
+    result.push_back(sc);
+  }
   return result;
 }
 

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -128,15 +128,12 @@ std::vector<SolverEnum> available_solver_enums() { return solver_enums; }
 std::vector<SolverConfiguration> available_solver_configurations()
 {
   std::vector<SolverConfiguration> configs;
-  std::vector<SolverEnum> enums = available_solver_enums();
-  for (SolverEnum e : enums)
+  for (SolverEnum e : available_solver_enums())
   {
-    SolverConfiguration sc;
-    sc.solver_enum = e;
-    sc.is_logging_solver = true;
-    configs.push_back(sc);
-    sc.is_logging_solver = false;
-    configs.push_back(sc);
+    SolverConfiguration sct(e, true);
+    SolverConfiguration scf(e, false);
+    configs.push_back(sct);
+    configs.push_back(scf);
   }
   return configs;
 }
@@ -154,12 +151,9 @@ std::vector<SolverEnum> available_interpolator_enums() {
 }
 
 std::vector<SolverConfiguration> available_interpolator_configurations() { 
-  std::vector<SolverEnum> enums = available_interpolator_enums();
   std::vector<SolverConfiguration> result;
-  for (SolverEnum e : enums) {
-    SolverConfiguration sc;
-    sc.solver_enum = e;
-    sc.is_logging_solver = false;
+  for (SolverEnum e : available_interpolator_enums()) {
+    SolverConfiguration sc(e, false);
     result.push_back(sc);
   }
   return result;
@@ -202,12 +196,10 @@ std::vector<SolverConfiguration> filter_solver_configurations(
   // compute result
   std::vector<SolverConfiguration> result;
   for (SolverEnum e : filtered_enums) {
-    SolverConfiguration sc;
-    sc.solver_enum = e;
-    sc.is_logging_solver = false;
-    result.push_back(sc);
-    sc.is_logging_solver = true;
-    result.push_back(sc);
+    SolverConfiguration scf(e, false);
+    SolverConfiguration sct(e, true);
+    result.push_back(scf);
+    result.push_back(sct);
   }
   return result;
 }

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -122,6 +122,46 @@ SmtSolver create_solver(SolverEnum se)
   }
 }
 
+SmtSolver create_solver(SolverConfiguration sc)
+{
+  SolverEnum se = sc.get_solver_enum();
+  bool logging = sc.get_is_logging_solver();
+  switch (se)
+  {
+#if BUILD_BTOR
+    case BTOR: {
+      return BoolectorSolverFactory::create(logging);
+      break;
+      ;
+    }
+#endif
+#if BUILD_CVC4
+    case CVC4: {
+      return CVC4SolverFactory::create(logging);
+      break;
+      ;
+    }
+#endif
+#if BUILD_MSAT
+    case MSAT: {
+      return MsatSolverFactory::create(logging);
+      break;
+      ;
+    }
+#endif
+#if BUILD_YICES2
+    case YICES2: {
+      return Yices2SolverFactory::create(logging);
+      break;
+      ;
+    }
+#endif
+    default: {
+      throw SmtException("Unhandled solver enum");
+    }
+  }
+}
+
 SmtSolver create_interpolating_solver(SolverEnum se)
 {
   switch (se)
@@ -146,6 +186,23 @@ const std::vector<SolverEnum> itp_enums({
 });
 
 std::vector<SolverEnum> available_solver_enums() { return solver_enums; }
+
+SolverConfiguration::SolverConfiguration(SolverEnum e, bool logging)
+    : solver_enum(e), is_logging_solver(logging)
+{
+}
+
+std::vector<SolverConfiguration> available_solver_configurations()
+{
+  std::vector<SolverConfiguration> configs;
+  std::vector<SolverEnum> enums = available_no_logging_solver_enums();
+  for (SolverEnum e : enums)
+  {
+    configs.push_back(SolverConfiguration(e, true));
+    configs.push_back(SolverConfiguration(e, false));
+  }
+  return configs;
+}
 
 // collect all the available non-logging solvers
 std::vector<SolverEnum> available_no_logging_solver_enums()

--- a/tests/available_solvers.cpp
+++ b/tests/available_solvers.cpp
@@ -42,87 +42,21 @@ namespace smt_tests {
 // list of regular (non-interpolator) solver enums
 const std::vector<SolverEnum> solver_enums({
 #if BUILD_BTOR
-  BTOR, BTOR_LOGGING,
+  BTOR
 #endif
 
 #if BUILD_CVC4
-      CVC4, CVC4_LOGGING,
+      CVC4
 #endif
 
 #if BUILD_MSAT
-      MSAT, MSAT_LOGGING,
+      MSAT
 #endif
 
 #if BUILD_YICES2
-      YICES2, YICES2_LOGGING,
+      YICES2
 #endif
 });
-
-
-SmtSolver create_solver(SolverEnum se)
-{
-  switch (se)
-  {
-#if BUILD_BTOR
-    case BTOR:
-    {
-      return BoolectorSolverFactory::create(false);
-      break;
-      ;
-    }
-    case BTOR_LOGGING:
-    {
-      return BoolectorSolverFactory::create(true);
-      break;
-      ;
-    }
-#endif
-#if BUILD_CVC4
-    case CVC4:
-    {
-      return CVC4SolverFactory::create(false);
-      break;
-      ;
-    }
-    case CVC4_LOGGING:
-    {
-      return CVC4SolverFactory::create(true);
-      break;
-      ;
-    }
-#endif
-#if BUILD_MSAT
-    case MSAT:
-    {
-      return MsatSolverFactory::create(false);
-      break;
-      ;
-    }
-    case MSAT_LOGGING:
-    {
-      return MsatSolverFactory::create(true);
-      break;
-      ;
-    }
-#endif
-#if BUILD_YICES2
-    case YICES2:
-    {
-      return Yices2SolverFactory::create(false);
-      break;
-      ;
-    }
-    case YICES2_LOGGING:
-    {
-      return Yices2SolverFactory::create(true);
-      break;
-      ;
-    }
-#endif
-    default: { throw SmtException("Unhandled solver enum");
-    }
-  }
-}
 
 SmtSolver create_solver(SolverConfiguration sc)
 {
@@ -166,11 +100,6 @@ SmtSolver create_solver(SolverConfiguration sc)
 
 SmtSolver create_interpolating_solver(SolverConfiguration sc) {
   SolverEnum se = sc.solver_enum;
-  return create_interpolating_solver(se);
-}
-
-SmtSolver create_interpolating_solver(SolverEnum se)
-{
   switch (se)
   {
 #if BUILD_MSAT
@@ -199,7 +128,7 @@ std::vector<SolverEnum> available_solver_enums() { return solver_enums; }
 std::vector<SolverConfiguration> available_solver_configurations()
 {
   std::vector<SolverConfiguration> configs;
-  std::vector<SolverEnum> enums = available_no_logging_solver_enums();
+  std::vector<SolverEnum> enums = available_solver_enums();
   for (SolverEnum e : enums)
   {
     SolverConfiguration sc;
@@ -210,52 +139,6 @@ std::vector<SolverConfiguration> available_solver_configurations()
     configs.push_back(sc);
   }
   return configs;
-}
-
-std::vector<SolverConfiguration> available_no_logging_solver_configurations() {
-  std::vector<SolverEnum> enums = available_no_logging_solver_enums();
-  std::vector<SolverConfiguration> result;
-  for (SolverEnum e : enums) {
-    SolverConfiguration sc;
-    sc.solver_enum = e;
-    sc.is_logging_solver = false;
-    result.push_back(sc);
-  }
-  return result;
-}
-
-// collect all the available non-logging solvers
-std::vector<SolverEnum> available_no_logging_solver_enums()
-{
-  std::vector<SolverEnum> enums;
-  for (auto se : solver_enums)
-  {
-    const std::unordered_set<SolverAttribute> & se_attrs =
-        get_solver_attributes(se);
-
-    if (se_attrs.find(LOGGING) == se_attrs.end())
-    {
-      enums.push_back(se);
-    }
-  }
-  return enums;
-}
-
-// collect all the available logging solvers
-std::vector<SolverEnum> available_logging_solver_enums()
-{
-  std::vector<SolverEnum> enums;
-  for (auto se : solver_enums)
-  {
-    const std::unordered_set<SolverAttribute> & se_attrs =
-        get_solver_attributes(se);
-
-    if (se_attrs.find(LOGGING) != se_attrs.end())
-    {
-      enums.push_back(se);
-    }
-  }
-  return enums;
 }
 
 std::vector<SolverEnum> available_interpolator_enums() { 
@@ -317,14 +200,7 @@ std::vector<SolverConfiguration> filter_solver_configurations(
 {
   // first get the enums
   std::vector<SolverEnum> filtered_enums = filter_solver_enums(attributes);
-  // remove all the logging enums
-  std::vector<SolverEnum> logging_enums = available_logging_solver_enums();
-  for (SolverEnum e : filtered_enums) {
-    if (std::find(logging_enums.begin(), logging_enums.end(), e) != logging_enums.end()) {
-      filtered_enums.erase(std::find(filtered_enums.begin(), filtered_enums.end(), e));
-    }
-  }
-  
+
   // compute result
   std::vector<SolverConfiguration> result;
   for (SolverEnum e : filtered_enums) {

--- a/tests/available_solvers.h
+++ b/tests/available_solvers.h
@@ -40,6 +40,10 @@ smt::SmtSolver create_solver(smt::SolverEnum se);
 /** Creates an interpolating SmtSolver of the provided type */
 smt::SmtSolver create_interpolating_solver(smt::SolverEnum se);
 
+/** Creates an interpolating SmtSolver of the provided type */
+smt::SmtSolver create_interpolating_solver(SolverConfiguration sc);
+
+
 // collect all the available solvers
 std::vector<smt::SolverEnum> available_solver_enums();
 
@@ -57,6 +61,9 @@ std::vector<smt::SolverEnum> available_logging_solver_enums();
 
 // collect all the available interpolating solvers
 std::vector<smt::SolverEnum> available_interpolator_enums();
+
+// collect all the available interpolating solvers
+std::vector<SolverConfiguration> available_interpolator_configurations();
 
 /** Filter the available solvers by a set of attributes
  * @return all available solvers that have *all* the attributes

--- a/tests/available_solvers.h
+++ b/tests/available_solvers.h
@@ -28,8 +28,15 @@ namespace smt_tests {
 
 struct SolverConfiguration
 {
+  // fields
   smt::SolverEnum solver_enum;
   bool is_logging_solver;
+  
+  // constructor
+  SolverConfiguration(smt::SolverEnum se, bool ils) {
+    solver_enum = se;
+    is_logging_solver = ils;  
+  }
 };
 
 /** Creates an SmtSolver of the provided type */

--- a/tests/available_solvers.h
+++ b/tests/available_solvers.h
@@ -26,14 +26,8 @@
 
 namespace smt_tests {
 
-class SolverConfiguration
+struct SolverConfiguration
 {
- public:
-  SolverConfiguration(smt::SolverEnum e, bool logging);
-  smt::SolverEnum get_solver_enum() { return solver_enum; }
-  bool get_is_logging_solver() { return is_logging_solver; }
-
- protected:
   smt::SolverEnum solver_enum;
   bool is_logging_solver;
 };

--- a/tests/available_solvers.h
+++ b/tests/available_solvers.h
@@ -32,13 +32,8 @@ struct SolverConfiguration
   bool is_logging_solver;
 };
 
-smt::SmtSolver create_solver(SolverConfiguration sc);
-
 /** Creates an SmtSolver of the provided type */
-smt::SmtSolver create_solver(smt::SolverEnum se);
-
-/** Creates an interpolating SmtSolver of the provided type */
-smt::SmtSolver create_interpolating_solver(smt::SolverEnum se);
+smt::SmtSolver create_solver(SolverConfiguration sc);
 
 /** Creates an interpolating SmtSolver of the provided type */
 smt::SmtSolver create_interpolating_solver(SolverConfiguration sc);
@@ -49,15 +44,6 @@ std::vector<smt::SolverEnum> available_solver_enums();
 
 // collect all the available solvers
 std::vector<SolverConfiguration> available_solver_configurations();
-
-// collect all the available non-logging solvers
-std::vector<smt::SolverEnum> available_no_logging_solver_enums();
-
-// collect all the available non-logging solvers
-std::vector<SolverConfiguration> available_no_logging_solver_configurations();
-
-// collect all the available logging solvers
-std::vector<smt::SolverEnum> available_logging_solver_enums();
 
 // collect all the available interpolating solvers
 std::vector<smt::SolverEnum> available_interpolator_enums();

--- a/tests/available_solvers.h
+++ b/tests/available_solvers.h
@@ -49,6 +49,9 @@ std::vector<SolverConfiguration> available_solver_configurations();
 // collect all the available non-logging solvers
 std::vector<smt::SolverEnum> available_no_logging_solver_enums();
 
+// collect all the available non-logging solvers
+std::vector<SolverConfiguration> available_no_logging_solver_configurations();
+
 // collect all the available logging solvers
 std::vector<smt::SolverEnum> available_logging_solver_enums();
 
@@ -59,6 +62,12 @@ std::vector<smt::SolverEnum> available_interpolator_enums();
  * @return all available solvers that have *all* the attributes
  */
 std::vector<smt::SolverEnum> filter_solver_enums(
+    const std::unordered_set<smt::SolverAttribute> attributes);
+
+/** Filter the available solvers by a set of attributes
+ * @return all available solvers that have *all* the attributes
+ */
+std::vector<SolverConfiguration> filter_solver_configurations(
     const std::unordered_set<smt::SolverAttribute> attributes);
 
 }  // namespace smt_tests

--- a/tests/available_solvers.h
+++ b/tests/available_solvers.h
@@ -26,6 +26,20 @@
 
 namespace smt_tests {
 
+class SolverConfiguration
+{
+ public:
+  SolverConfiguration(smt::SolverEnum e, bool logging);
+  smt::SolverEnum get_solver_enum() { return solver_enum; }
+  bool get_is_logging_solver() { return is_logging_solver; }
+
+ protected:
+  smt::SolverEnum solver_enum;
+  bool is_logging_solver;
+};
+
+smt::SmtSolver create_solver(SolverConfiguration sc);
+
 /** Creates an SmtSolver of the provided type */
 smt::SmtSolver create_solver(smt::SolverEnum se);
 
@@ -34,6 +48,9 @@ smt::SmtSolver create_interpolating_solver(smt::SolverEnum se);
 
 // collect all the available solvers
 std::vector<smt::SolverEnum> available_solver_enums();
+
+// collect all the available solvers
+std::vector<SolverConfiguration> available_solver_configurations();
 
 // collect all the available non-logging solvers
 std::vector<smt::SolverEnum> available_no_logging_solver_enums();

--- a/tests/test-array.cpp
+++ b/tests/test-array.cpp
@@ -27,7 +27,7 @@ using namespace std;
 namespace smt_tests {
 
 class ArrayModelTests : public ::testing::Test,
-                        public ::testing::WithParamInterface<SolverEnum>
+                        public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -77,6 +77,6 @@ TEST_P(ArrayModelTests, TestArrayModel)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedArrayModelTests,
     ArrayModelTests,
-    testing::ValuesIn(filter_solver_enums({ ARRAY_MODELS })));
+    testing::ValuesIn(filter_solver_configurations({ ARRAY_MODELS })));
 
 }  // namespace smt_tests

--- a/tests/test-dt.cpp
+++ b/tests/test-dt.cpp
@@ -27,7 +27,7 @@ using namespace std;
 namespace smt_tests {
 
 class DTTests : public ::testing::Test,
-                 public ::testing::WithParamInterface<SolverEnum>
+                 public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -42,7 +42,10 @@ class DTTests : public ::testing::Test,
 
 TEST_P(DTTests, DatatypeDecl)
 {
-
+    SolverConfiguration sc = GetParam();
+    if (sc.is_logging_solver) {
+      return;
+    }
     Term five = s->make_term(5, intsort);
 
     // Make datatype sort
@@ -92,6 +95,6 @@ TEST_P(DTTests, DatatypeDecl)
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverDTTests,
                          DTTests,
-                         testing::ValuesIn(filter_solver_enums({ THEORY_DATATYPE })));
+                         testing::ValuesIn(filter_solver_configurations({ THEORY_DATATYPE })));
 
 }

--- a/tests/test-int.cpp
+++ b/tests/test-int.cpp
@@ -27,7 +27,7 @@ using namespace std;
 namespace smt_tests {
 
 class IntTests : public ::testing::Test,
-                 public ::testing::WithParamInterface<SolverEnum>
+                 public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -83,6 +83,6 @@ TEST_P(IntTests, Bv2Int)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverIntTests,
     IntTests,
-    testing::ValuesIn(filter_solver_enums({ THEORY_INT })));
+    testing::ValuesIn(filter_solver_configurations({ THEORY_INT })));
 
 }  // namespace smt_tests

--- a/tests/test-logging-solver.cpp
+++ b/tests/test-logging-solver.cpp
@@ -152,6 +152,6 @@ TEST_P(LoggingTests, Compare)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverLoggingTests,
     LoggingTests,
-    testing::ValuesIn(available_no_logging_solver_configurations()));
+    testing::ValuesIn(available_solver_configurations()));
 
 }  // namespace smt_tests

--- a/tests/test-logging-solver.cpp
+++ b/tests/test-logging-solver.cpp
@@ -29,7 +29,7 @@ using namespace std;
 namespace smt_tests {
 
 class LoggingTests : public ::testing::Test,
-                     public ::testing::WithParamInterface<SolverEnum>
+                     public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -152,6 +152,6 @@ TEST_P(LoggingTests, Compare)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverLoggingTests,
     LoggingTests,
-    testing::ValuesIn(available_no_logging_solver_enums()));
+    testing::ValuesIn(available_no_logging_solver_configurations()));
 
 }  // namespace smt_tests

--- a/tests/test-term-translation.cpp
+++ b/tests/test-term-translation.cpp
@@ -30,7 +30,7 @@ using namespace std;
 namespace smt_tests {
 
 class SelfTranslationTests : public ::testing::Test,
-                             public ::testing::WithParamInterface<SolverEnum>
+                             public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -49,7 +49,7 @@ class SelfTranslationTests : public ::testing::Test,
 };
 
 class SelfTranslationIntTests : public ::testing::Test,
-                                public ::testing::WithParamInterface<SolverEnum>
+                                public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -69,7 +69,7 @@ class SelfTranslationIntTests : public ::testing::Test,
 
 class TranslationTests
     : public ::testing::Test,
-      public ::testing::WithParamInterface<tuple<SolverEnum, SolverEnum>>
+      public ::testing::WithParamInterface<tuple<SolverConfiguration, SolverConfiguration>>
 {
  protected:
   void SetUp() override
@@ -333,25 +333,25 @@ TEST_P(BoolArrayTranslationTests, Arrays)
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedSelfTranslationTests,
                          SelfTranslationTests,
-                         testing::ValuesIn(filter_solver_enums({ TERMITER })));
+                         testing::ValuesIn(filter_solver_configurations({ TERMITER })));
 
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSelfTranslationIntTests,
     SelfTranslationIntTests,
-    testing::ValuesIn(filter_solver_enums({ FULL_TRANSFER, THEORY_INT })));
+    testing::ValuesIn(filter_solver_configurations({ FULL_TRANSFER, THEORY_INT })));
 
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedTranslationTests,
     TranslationTests,
-    testing::Combine(testing::ValuesIn(filter_solver_enums({ TERMITER })),
-                     testing::ValuesIn(filter_solver_enums({ TERMITER }))));
+    testing::Combine(testing::ValuesIn(filter_solver_configurations({ TERMITER })),
+                     testing::ValuesIn(filter_solver_configurations({ TERMITER }))));
 
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedBoolArrayTranslationTests,
     BoolArrayTranslationTests,
-    testing::Combine(testing::ValuesIn(filter_solver_enums(
+    testing::Combine(testing::ValuesIn(filter_solver_configurations(
                          { TERMITER, CONSTARR, ARRAY_FUN_BOOLS })),
-                     testing::ValuesIn(filter_solver_enums(
+                     testing::ValuesIn(filter_solver_configurations(
                          { TERMITER, CONSTARR, ARRAY_FUN_BOOLS }))));
 
 }  // namespace smt_tests

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -27,7 +27,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnsatCoreTests : public ::testing::Test,
-                 public ::testing::WithParamInterface<SolverEnum>
+                 public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -68,6 +68,6 @@ TEST_P(UnsatCoreTests, UnsatCore)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverUnsatCoreTests,
     UnsatCoreTests,
-    testing::ValuesIn(filter_solver_enums({ UNSAT_CORE })));
+    testing::ValuesIn(filter_solver_configurations({ UNSAT_CORE })));
 
 }  // namespace smt_tests

--- a/tests/test_itp.cpp
+++ b/tests/test_itp.cpp
@@ -29,7 +29,7 @@ using namespace std;
 namespace smt_tests {
 
 class ItpTests : public ::testing::Test,
-                 public ::testing::WithParamInterface<SolverEnum>
+                 public ::testing::WithParamInterface<SolverConfiguration>
 {
 protected:
   void SetUp() override
@@ -68,5 +68,5 @@ TEST_P(ItpTests, Test_ITP)
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedItpTests,
                          ItpTests,
-                         testing::ValuesIn(available_interpolator_enums()));
+                         testing::ValuesIn(available_interpolator_configurations()));
 }

--- a/tests/unit/unit-arrays.cpp
+++ b/tests/unit/unit-arrays.cpp
@@ -27,7 +27,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitArrayTests : public ::testing::Test,
-                       public ::testing::WithParamInterface<SolverEnum>
+                       public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -74,6 +74,6 @@ TEST_P(UnitArrayTests, ConstArr)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedUnitArray,
     UnitArrayTests,
-    testing::ValuesIn(filter_solver_enums({ CONSTARR, ARRAY_MODELS })));
+    testing::ValuesIn(filter_solver_configurations({ CONSTARR, ARRAY_MODELS })));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-op.cpp
+++ b/tests/unit/unit-op.cpp
@@ -33,7 +33,7 @@ class UnitPrimOpTests : public ::testing::Test,
 };
 
 class UnitTests : public ::testing::Test,
-                  public ::testing::WithParamInterface<SolverEnum>
+                  public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -144,6 +144,6 @@ INSTANTIATE_TEST_SUITE_P(ParameterizedPrimOp,
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnit,
                          UnitTests,
-                         testing::ValuesIn(filter_solver_enums({ TERMITER })));
+                         testing::ValuesIn(filter_solver_configurations({ TERMITER })));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-printing.cpp
+++ b/tests/unit/unit-printing.cpp
@@ -27,7 +27,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitPrintTests : public ::testing::Test,
-                       public testing::WithParamInterface<SolverEnum>
+                       public testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -96,6 +96,6 @@ TEST_P(UnitPrintTests, PrintValueAs)
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverPringUnit,
                          UnitPrintTests,
-                         testing::ValuesIn(available_solver_enums()));
+                         testing::ValuesIn(available_solver_configurations()));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-quantifiers.cpp
+++ b/tests/unit/unit-quantifiers.cpp
@@ -27,7 +27,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitQuantifierTests : public ::testing::Test,
-                            public testing::WithParamInterface<SolverEnum>
+                            public testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -43,7 +43,7 @@ class UnitQuantifierTests : public ::testing::Test,
 };
 
 class UnitQuantifierIterTests : public ::testing::Test,
-                                public testing::WithParamInterface<SolverEnum>
+                                public testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -111,11 +111,11 @@ TEST_P(UnitQuantifierIterTests, QuantifierFunCheck)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedQuantifierTests,
     UnitQuantifierTests,
-    testing::ValuesIn(filter_solver_enums({ QUANTIFIERS })));
+    testing::ValuesIn(filter_solver_configurations({ QUANTIFIERS })));
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedQuantifierIterTests,
                          UnitQuantifierIterTests,
-                         testing::ValuesIn(filter_solver_enums({ QUANTIFIERS,
+                         testing::ValuesIn(filter_solver_configurations({ QUANTIFIERS,
                                                                  TERMITER })));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-reset-assertions.cpp
+++ b/tests/unit/unit-reset-assertions.cpp
@@ -32,13 +32,14 @@ namespace smt_tests {
 
 class UnitResetAssertionsTests
     : public ::testing::Test,
-      public ::testing::WithParamInterface<SolverEnum>
+      public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
   {
-    SolverEnum se = GetParam();
-    s = create_solver(se);
+    SolverConfiguration sc = GetParam();
+    SolverEnum se = sc.solver_enum;
+    s = create_solver(sc);
     s->set_opt("produce-models", "true");
     s->set_opt("incremental", "true");
 
@@ -120,6 +121,6 @@ TEST(UnitBtorResetAssertionsTests, ResetAssertionsException)
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnitResetAssertions,
                          UnitResetAssertionsTests,
-                         testing::ValuesIn(available_solver_enums()));
+                         testing::ValuesIn(available_solver_configurations()));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-reset-assertions.cpp
+++ b/tests/unit/unit-reset-assertions.cpp
@@ -104,7 +104,8 @@ TEST(UnitBtorResetAssertionsTests, ResetAssertionsException)
   // Underlying solver boolector does not have reset_assertions
   // but we can approximate it using solving contexts, but this
   // might impact performance
-  SmtSolver s = create_solver(BTOR);
+  SolverConfiguration sc(BTOR, false);
+  SmtSolver s = create_solver(sc);
   s->set_opt("produce-models", "true");
   s->set_opt("incremental", "true");
   Sort bvsort = s->make_sort(BV, 8);

--- a/tests/unit/unit-reset-assertions.cpp
+++ b/tests/unit/unit-reset-assertions.cpp
@@ -43,7 +43,7 @@ class UnitResetAssertionsTests
     s->set_opt("produce-models", "true");
     s->set_opt("incremental", "true");
 
-    if (se == BTOR || se == BTOR_LOGGING)
+    if (se == BTOR)
     {
       // special option for boolector
       // not enabled by default because it can affect performance

--- a/tests/unit/unit-solver-enums.cpp
+++ b/tests/unit/unit-solver-enums.cpp
@@ -27,7 +27,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitSolverEnumTests : public ::testing::Test,
-                            public ::testing::WithParamInterface<SolverEnum>
+                            public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override { s = create_solver(GetParam()); }
@@ -36,24 +36,13 @@ class UnitSolverEnumTests : public ::testing::Test,
 
 TEST_P(UnitSolverEnumTests, SolverEnumMatch)
 {
-  ASSERT_EQ(GetParam(), s->get_solver_enum());
-}
-
-TEST_P(UnitSolverEnumTests, LoggingMapping)
-{
-  SolverEnum se = GetParam();
-  if (!is_logging_solver_enum(se))
-  {
-    ASSERT_NO_THROW(get_logging_solver_enum(se));
-  }
-  else
-  {
-    ASSERT_THROW(get_logging_solver_enum(se), IncorrectUsageException);
-  }
+  SolverConfiguration sc = GetParam();
+  SolverEnum se = sc.solver_enum;
+  ASSERT_EQ(se, s->get_solver_enum());
 }
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSolverEnum,
                          UnitSolverEnumTests,
-                         testing::ValuesIn(available_solver_enums()));
+                         testing::ValuesIn(available_solver_configurations()));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-solving-interface.cpp
+++ b/tests/unit/unit-solving-interface.cpp
@@ -28,7 +28,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitSolveTests : public ::testing::Test,
-                       public testing::WithParamInterface<SolverEnum>
+                       public testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -63,6 +63,6 @@ TEST_P(UnitSolveTests, CheckSatAssuming)
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSolveTests,
                          UnitSolveTests,
-                         testing::ValuesIn(filter_solver_enums({ TERMITER })));
+                         testing::ValuesIn(filter_solver_configurations({ TERMITER })));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-sort-inference.cpp
+++ b/tests/unit/unit-sort-inference.cpp
@@ -25,7 +25,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitSortInferenceTests : public ::testing::Test,
-                               public ::testing::WithParamInterface<SolverEnum>
+                               public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -271,10 +271,10 @@ TEST_P(UnitArithmeticSortInferenceTests, ArithmeticSortComputation)
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSortInference,
                          UnitSortInferenceTests,
-                         testing::ValuesIn(available_solver_enums()));
+                         testing::ValuesIn(available_solver_configurations()));
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitArithmeticSortInference,
                          UnitArithmeticSortInferenceTests,
-                         testing::ValuesIn(filter_solver_enums({ THEORY_INT, THEORY_REAL })));
+                         testing::ValuesIn(filter_solver_configurations({ THEORY_INT, THEORY_REAL })));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-sort.cpp
+++ b/tests/unit/unit-sort.cpp
@@ -135,7 +135,7 @@ TEST_P(UnitSortTests, UninterpretedSort)
 
 TEST_P(UnitSortTests, UninterpSortEquality)
 {
-  if (is_logging_solver_enum(s->get_solver_enum()))
+  if (solver_has_attribute(s->get_solver_enum(), LOGGING))
   {
     return;
   }

--- a/tests/unit/unit-sort.cpp
+++ b/tests/unit/unit-sort.cpp
@@ -38,7 +38,7 @@ TEST(SortKind, ToString)
 }
 
 class UnitSortTests : public ::testing::Test,
-                      public ::testing::WithParamInterface<SolverEnum>
+                      public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -147,7 +147,9 @@ TEST_P(UnitSortTests, UninterpSortEquality)
   }
   catch (SmtException & e)
   {
-    std::cout << "got exception for SolverEnum: " << GetParam() << std::endl;
+    SolverConfiguration sc = GetParam();
+    SolverEnum se = sc.solver_enum;
+    std::cout << "got exception for SolverEnum: " << se << std::endl;
     return;
   }
 
@@ -193,6 +195,6 @@ TEST_P(UnitSortArithTests, SameSortDiffObj)
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSortTests,
                          UnitSortTests,
-                         testing::ValuesIn(available_solver_enums()));
+                         testing::ValuesIn(available_solver_configurations()));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-term-hashtable.cpp
+++ b/tests/unit/unit-term-hashtable.cpp
@@ -25,7 +25,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitTestsHashTable : public testing::Test,
-                           public testing::WithParamInterface<SolverEnum>
+                           public testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -71,6 +71,6 @@ TEST_P(UnitTestsHashTable, HashTable)
 INSTANTIATE_TEST_SUITE_P(
     ParametrizedUnitHashTable,
     UnitTestsHashTable,
-    testing::ValuesIn(available_no_logging_solver_enums()));
+    testing::ValuesIn(available_no_logging_solver_configurations()));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-term-hashtable.cpp
+++ b/tests/unit/unit-term-hashtable.cpp
@@ -25,7 +25,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitTestsHashTable : public testing::Test,
-                           public testing::WithParamInterface<SolverConfiguration>
+                           public testing::WithParamInterface<SolverEnum>
 {
  protected:
   void SetUp() override
@@ -33,7 +33,11 @@ class UnitTestsHashTable : public testing::Test,
     // need to make sure we're not using a LoggingSolver
     // otherwise the reference counts of terms will be influenced
     // thus, use the "lite" solvers
-    s = create_solver(GetParam());
+    SolverEnum se = GetParam();
+    SolverConfiguration sc;
+    sc.solver_enum = se;
+    sc.is_logging_solver = false;
+    s = create_solver(sc);
 
     bvsort = s->make_sort(BV, 4);
     funsort = s->make_sort(FUNCTION, SortVec{ bvsort, bvsort });
@@ -71,6 +75,6 @@ TEST_P(UnitTestsHashTable, HashTable)
 INSTANTIATE_TEST_SUITE_P(
     ParametrizedUnitHashTable,
     UnitTestsHashTable,
-    testing::ValuesIn(available_no_logging_solver_configurations()));
+    testing::ValuesIn(available_solver_enums()));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-term-hashtable.cpp
+++ b/tests/unit/unit-term-hashtable.cpp
@@ -34,9 +34,7 @@ class UnitTestsHashTable : public testing::Test,
     // otherwise the reference counts of terms will be influenced
     // thus, use the "lite" solvers
     SolverEnum se = GetParam();
-    SolverConfiguration sc;
-    sc.solver_enum = se;
-    sc.is_logging_solver = false;
+    SolverConfiguration sc(se, false);
     s = create_solver(sc);
 
     bvsort = s->make_sort(BV, 4);

--- a/tests/unit/unit-term.cpp
+++ b/tests/unit/unit-term.cpp
@@ -27,7 +27,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitTermTests : public ::testing::Test,
-                      public testing::WithParamInterface<SolverEnum>
+                      public testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -64,6 +64,6 @@ TEST_P(UnitTermTests, Array)
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnitTerm,
                          UnitTermTests,
-                         testing::ValuesIn(available_solver_enums()));
+                         testing::ValuesIn(available_solver_configurations()));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-termiter.cpp
+++ b/tests/unit/unit-termiter.cpp
@@ -28,7 +28,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitTests : public ::testing::Test,
-                  public testing::WithParamInterface<SolverEnum>
+                  public testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -124,10 +124,10 @@ TEST_P(UnitTests, CopyIter)
 
 INSTANTIATE_TEST_SUITE_P(ParametrizedUnit,
                          UnitTests,
-                         testing::ValuesIn(filter_solver_enums({ TERMITER })));
+                         testing::ValuesIn(filter_solver_configurations({ TERMITER })));
 
 INSTANTIATE_TEST_SUITE_P(ParametrizedConstArrUnit,
                          ConstArrUnitTests,
-                         testing::ValuesIn(filter_solver_enums({ CONSTARR })));
+                         testing::ValuesIn(filter_solver_configurations({ CONSTARR })));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-transfer.cpp
+++ b/tests/unit/unit-transfer.cpp
@@ -27,7 +27,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitTransferTests : public ::testing::Test,
-                          public ::testing::WithParamInterface<SolverEnum>
+                          public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -88,6 +88,6 @@ TEST_P(UnitQuantifierTransferTests, MonotonicUF)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedTransferUnit,
     UnitTransferTests,
-    testing::ValuesIn(filter_solver_enums({ FULL_TRANSFER })));
+    testing::ValuesIn(filter_solver_configurations({ FULL_TRANSFER })));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-util.cpp
+++ b/tests/unit/unit-util.cpp
@@ -29,7 +29,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitUtilTests : public ::testing::Test,
-                      public ::testing::WithParamInterface<SolverEnum>
+                      public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -104,6 +104,6 @@ TEST_P(UnitUtilTests, DisjunctivePartition)
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitUtilTests,
                          UnitUtilTests,
-                         testing::ValuesIn(filter_solver_enums({ TERMITER })));
+                         testing::ValuesIn(filter_solver_configurations({ TERMITER })));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-walker.cpp
+++ b/tests/unit/unit-walker.cpp
@@ -28,7 +28,7 @@ using namespace std;
 namespace smt_tests {
 
 class UnitWalkerTests : public ::testing::Test,
-                        public ::testing::WithParamInterface<SolverEnum>
+                        public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -117,6 +117,6 @@ TEST_P(UnitWalkerTests, FunSubstitution)
 
 INSTANTIATE_TEST_SUITE_P(ParametrizedUnitWalker,
                          UnitWalkerTests,
-                         testing::ValuesIn(filter_solver_enums({ TERMITER })));
+                         testing::ValuesIn(filter_solver_configurations({ TERMITER })));
 
 }  // namespace smt_tests


### PR DESCRIPTION
This PR introduces a new `struct`, `SolverConfiguration` for the testing infra-structure.
A `SolverConfiguration` consists of a `SolverEnum` and a Boolean flag that states whether this solver is a `LoggingSolver`.
Tests are now parameterized by `SolverConfiguration`.
The `_LOGGING` enums are deleted.