### PR TITLE
Find and link gmpxx for mathsat backend

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -5,6 +5,7 @@
 
 find_path(GMP_INCLUDE_DIR NAMES gmp.h gmpxx.h)
 find_library(GMP_LIBRARIES NAMES gmp)
+find_library(GMPXX_LIBRARIES NAMES gmpxx)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GMP DEFAULT_MSG GMP_INCLUDE_DIR GMP_LIBRARIES)
@@ -12,4 +13,7 @@ find_package_handle_standard_args(GMP DEFAULT_MSG GMP_INCLUDE_DIR GMP_LIBRARIES)
 mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARIES)
 if(GMP_LIBRARIES)
   message(STATUS "Found GMP libs: ${GMP_LIBRARIES}")
+endif()
+if (GMPXX_LIBRARIES)
+  message(STATUS "Found GMPXX libs: ${GMPXX_LIBRARIES}")
 endif()

--- a/msat/CMakeLists.txt
+++ b/msat/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories (smt-switch-msat PUBLIC "${GMP_INCLUDE_DIR}")
 target_link_libraries(smt-switch-msat "${MSAT_HOME}/lib/libmathsat.a")
 target_link_libraries(smt-switch-msat smt-switch)
 target_link_libraries(smt-switch-msat ${GMP_LIBRARIES})
+target_link_libraries(smt-switch-msat ${GMPXX_LIBRARIES})
 
 if (SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
   # we want the static library to include the mathsat source

--- a/travis-scripts/setup-msat.sh
+++ b/travis-scripts/setup-msat.sh
@@ -43,13 +43,13 @@ if [ ! -d "$DEPS/mathsat" ]; then
     cd $DEPS
     mkdir mathsat
     if [[ "$OSTYPE" == linux* ]]; then
-        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.3-linux-x86_64.tar.gz
+        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.4-linux-x86_64.tar.gz
     elif [[ "$OSTYPE" == darwin* ]]; then
-        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.3-darwin-libcxx-x86_64.tar.gz
+        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.4-darwin-libcxx-x86_64.tar.gz
     elif [[ "$OSTYPE" == msys* ]]; then
-        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.3-win64-msvc.zip
+        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.4-win64-msvc.zip
     elif [[ "$OSTYPE" == cygwin* ]]; then
-        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.3-linux-x86_64.tar.gz
+        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.4-linux-x86_64.tar.gz
     else
         echo "Unrecognized OSTYPE=$OSTYPE"
         exit 1


### PR DESCRIPTION
Also updates the version of MathSAT used in CI for testing (new one requires gmpxx).