### PR TITLE
Add getters for solver-specific objects

### DIFF
--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -115,6 +115,11 @@ class BoolectorSolver : public AbsSmtSolver
   Term apply_prim_op(PrimOp op, TermVec terms) const;
   void dump_smt2(std::string filename) const override;
 
+  // getters for solver-specific objects
+  // for interacting with third-party Boolector-specific software
+
+  Btor * get_btor() const { return btor; };
+
  protected:
   Btor * btor;
   // store the names of created symbols

--- a/btor/include/boolector_sort.h
+++ b/btor/include/boolector_sort.h
@@ -46,6 +46,11 @@ class BoolectorSortBase : public AbsSort
   bool compare(const Sort s) const override;
   SortKind get_sort_kind() const override { return sk; };
 
+  // getters for solver-specific objects
+  // for interacting with third-party Boolector-specific software
+
+  BoolectorSort get_btor_sort() const { return sort; };
+
  protected:
   Btor * btor;
   BoolectorSort sort;

--- a/btor/include/boolector_term.h
+++ b/btor/include/boolector_term.h
@@ -90,6 +90,11 @@ class BoolectorTerm : public AbsTerm
   TermIter end() override;
   std::string print_value_as(SortKind sk) override;
 
+  // getters for solver-specific objects
+  // for interacting with third-party Boolector-specific software
+
+  BoolectorNode * get_btor_node() const { return node; };
+
  protected:
   Btor * btor;
   // the actual API level node that is used

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -106,8 +106,13 @@ class CVC4Solver : public AbsSmtSolver
   void reset() override;
   void reset_assertions() override;
   void dump_smt2(std::string filename) const override;
+
   // helpers
   ::CVC4::api::Op make_cvc4_op(Op op) const;
+
+  // getters for solver-specific objects
+  // for interacting with third-party CVC4-specific software
+  const ::CVC4::api::Solver & get_cvc4_solver() const { return solver; };
 
  protected:
   ::CVC4::api::Solver solver;

--- a/cvc4/include/cvc4_sort.h
+++ b/cvc4/include/cvc4_sort.h
@@ -48,6 +48,10 @@ namespace smt
     bool compare(const Sort) const override;
     SortKind get_sort_kind() const override;
 
+    // getters for solver-specific objects
+    // for interacting with third-party CVC4-specific software
+    ::CVC4::api::Sort get_cvc4_sort() const { return sort; };
+
    protected:
     ::CVC4::api::Sort sort;
 

--- a/cvc4/include/cvc4_term.h
+++ b/cvc4/include/cvc4_term.h
@@ -54,6 +54,10 @@ namespace smt {
    bool operator==(const CVC4TermIter & it);
    bool operator!=(const CVC4TermIter & it);
 
+   // getters for solver-specific objects
+   // for interacting with third-party CVC4-specific software
+   ::CVC4::api::Term get_cvc4_term() const { return term; };
+
   protected:
     bool equal(const TermIterBase & other) const override;
 

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -124,6 +124,10 @@ class MsatSolver : public AbsSmtSolver
 
   void dump_smt2(std::string filename) const override;
 
+  // getters for solver-specific objects
+  // for interacting with third-party MathSAT-specific software
+  msat_env get_msat_env() const { return env; };
+
  protected:
   msat_config cfg;
   msat_env env;

--- a/msat/include/msat_sort.h
+++ b/msat/include/msat_sort.h
@@ -43,6 +43,10 @@ class MsatSort : public AbsSort
   bool compare(const Sort) const override;
   SortKind get_sort_kind() const override;
 
+  // getters for solver-specific objects
+  // for interacting with third-party MathSAT-specific software
+  msat_type get_msat_type() const { return type; }
+
  protected:
   msat_env env;
   msat_type type;

--- a/msat/include/msat_term.h
+++ b/msat/include/msat_term.h
@@ -81,6 +81,26 @@ class MsatTerm : public AbsTerm
   TermIter end() override;
   std::string print_value_as(SortKind sk) override;
 
+  // getters for solver-specific objects
+  // for interacting with third-party MathSAT-specific software
+  msat_term get_msat_term() const
+  {
+    if (is_uf)
+    {
+      throw IncorrectUsageException("Cannot get msat_term from UF.");
+    }
+    return term;
+  }
+
+  msat_decl get_msat_decl() const
+  {
+    if (!is_uf)
+    {
+      throw IncorrectUsageException("Cannot get msat_decl from term.");
+    }
+    return decl;
+  }
+
  protected:
   msat_env env;
   msat_term term;


### PR DESCRIPTION
This allows a user to recover the solver-specific objects (perhaps after casting an abstract object). It is an advanced feature but can be useful for interacting with solver-specific solver -- e.g. a model checker written for just a specific solver.