### PR TITLE
Add solver-specific headers to install

### DIFF
--- a/btor/CMakeLists.txt
+++ b/btor/CMakeLists.txt
@@ -40,3 +40,7 @@ if (SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
 endif()
 
 install(TARGETS smt-switch-btor DESTINATION lib)
+# install headers -- for expert use only
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+  DESTINATION include/smt-switch
+  FILES_MATCHING PATTERN "*.h")

--- a/cvc4/CMakeLists.txt
+++ b/cvc4/CMakeLists.txt
@@ -58,3 +58,7 @@ if (SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
 endif()
 
 install(TARGETS smt-switch-cvc4 DESTINATION lib)
+# install headers -- for expert use only
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+  DESTINATION include/smt-switch
+  FILES_MATCHING PATTERN "*.h")

--- a/msat/CMakeLists.txt
+++ b/msat/CMakeLists.txt
@@ -35,3 +35,7 @@ if (SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
 endif()
 
 install(TARGETS smt-switch-msat DESTINATION lib)
+# install headers -- for expert use only
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+  DESTINATION include/smt-switch
+  FILES_MATCHING PATTERN "*.h")

--- a/yices2/CMakeLists.txt
+++ b/yices2/CMakeLists.txt
@@ -34,3 +34,7 @@ if (SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
 endif()
 
 install(TARGETS smt-switch-yices2 DESTINATION lib)
+# install headers -- for expert use only
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+  DESTINATION include/smt-switch
+  FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
Expose the solver-specific headers in the installation. This allows expert users to cast a solver to its specific implementation and retrieve the underlying solver objects. For example, this can be used to interface an smt-switch frontend with a solver-specific backend library.