### PR TITLE
Increase version number

### DIFF
--- a/contrib/wheels/build_wheel.py
+++ b/contrib/wheels/build_wheel.py
@@ -105,7 +105,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='smt-switch',
-    version='0.2.1',
+    version='0.2.2',
     author='Makai Mann',
     ext_modules=[CMakeExtension('smt-switch')],
     cmdclass=dict(build_ext=CMakeBuild),

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from distutils.core import Extension
 
 setup(name='smt_switch',
-      version='0.2.1',
+      version='0.2.2',
       long_description='python bindings for the C++ solver-agnostic SMT solving library, smt-switch',
       url='http://github.com/makaimann/smt-switch',
       license='BSD',


### PR DESCRIPTION
It's not possible to re-upload the same version number to PyPi. Thus, this increments the version number for a new PyPi release.