### PR TITLE
Take a const reference in Sort compare

### DIFF
--- a/btor/include/boolector_sort.h
+++ b/btor/include/boolector_sort.h
@@ -43,7 +43,7 @@ class BoolectorSortBase : public AbsSort
   size_t get_arity() const override;
   SortVec get_uninterpreted_param_sorts() const override;
   Datatype get_datatype() const override;
-  bool compare(const Sort s) const override;
+  bool compare(const Sort & s) const override;
   SortKind get_sort_kind() const override { return sk; };
 
   // getters for solver-specific objects

--- a/btor/src/boolector_sort.cpp
+++ b/btor/src/boolector_sort.cpp
@@ -92,7 +92,7 @@ Datatype BoolectorSortBase::get_datatype() const
   throw NotImplementedException("get_datatype");
 };
 
-bool BoolectorSortBase::compare(const Sort s) const
+bool BoolectorSortBase::compare(const Sort & s) const
 {
   std::shared_ptr<BoolectorSortBase> bs =
       std::static_pointer_cast<BoolectorSortBase>(s);

--- a/cvc4/include/cvc4_sort.h
+++ b/cvc4/include/cvc4_sort.h
@@ -45,7 +45,7 @@ namespace smt
     size_t get_arity() const override;
     SortVec get_uninterpreted_param_sorts() const override;
     Datatype get_datatype() const override;
-    bool compare(const Sort) const override;
+    bool compare(const Sort &) const override;
     SortKind get_sort_kind() const override;
 
     // getters for solver-specific objects

--- a/cvc4/src/cvc4_sort.cpp
+++ b/cvc4/src/cvc4_sort.cpp
@@ -99,7 +99,7 @@ SortVec CVC4Sort::get_uninterpreted_param_sorts() const
   return param_sorts;
 }
 
-bool CVC4Sort::compare(const Sort s) const
+bool CVC4Sort::compare(const Sort & s) const
 {
   std::shared_ptr<CVC4Sort> cs = std::static_pointer_cast<CVC4Sort>(s);
   return sort == cs->sort;

--- a/include/logging_sort.h
+++ b/include/logging_sort.h
@@ -47,7 +47,7 @@ class LoggingSort : public AbsSort
   virtual ~LoggingSort(){};
   // implementations
   SortKind get_sort_kind() const override;
-  bool compare(const Sort s) const override;
+  bool compare(const Sort & s) const override;
   // dispatch to underlying sort
   std::size_t hash() const override;
 

--- a/include/sort.h
+++ b/include/sort.h
@@ -77,7 +77,7 @@ class AbsSort
   virtual size_t get_arity() const = 0;
   virtual std::vector<Sort> get_uninterpreted_param_sorts() const = 0;
   virtual Datatype get_datatype() const = 0;
-  virtual bool compare(const Sort sort) const = 0;
+  virtual bool compare(const Sort & sort) const = 0;
   virtual SortKind get_sort_kind() const = 0;
 };
 

--- a/msat/include/msat_sort.h
+++ b/msat/include/msat_sort.h
@@ -40,7 +40,7 @@ class MsatSort : public AbsSort
   size_t get_arity() const override;
   SortVec get_uninterpreted_param_sorts() const override;
   Datatype get_datatype() const override;
-  bool compare(const Sort) const override;
+  bool compare(const Sort &) const override;
   SortKind get_sort_kind() const override;
 
   // getters for solver-specific objects

--- a/msat/src/msat_sort.cpp
+++ b/msat/src/msat_sort.cpp
@@ -133,7 +133,7 @@ Datatype MsatSort::get_datatype() const
   throw NotImplementedException("get_datatype");
 };
 
-bool MsatSort::compare(const Sort s) const
+bool MsatSort::compare(const Sort & s) const
 {
   std::shared_ptr<MsatSort> msort = std::static_pointer_cast<MsatSort>(s);
   return msat_type_equals(type, msort->type);

--- a/src/logging_sort.cpp
+++ b/src/logging_sort.cpp
@@ -129,7 +129,7 @@ Sort make_logging_sort(SortKind sk, Sort s, SortVec sorts)
 // implementations
 SortKind LoggingSort::get_sort_kind() const { return sk; }
 
-bool LoggingSort::compare(const Sort s) const
+bool LoggingSort::compare(const Sort & s) const
 {
   SortKind other_sk = s->get_sort_kind();
   if (sk != other_sk)

--- a/yices2/include/yices2_sort.h
+++ b/yices2/include/yices2_sort.h
@@ -47,7 +47,7 @@ class Yices2Sort : public AbsSort
   size_t get_arity() const override;
   SortVec get_uninterpreted_param_sorts() const override;
   Datatype get_datatype() const override;
-  bool compare(const Sort s) const override;
+  bool compare(const Sort & s) const override;
   SortKind get_sort_kind() const override;
   type_t get_ytype() { return type; };
 

--- a/yices2/src/yices2_sort.cpp
+++ b/yices2/src/yices2_sort.cpp
@@ -130,7 +130,7 @@ Datatype Yices2Sort::get_datatype() const
   throw NotImplementedException("get_datatype");
 };
 
-bool Yices2Sort::compare(const Sort s) const
+bool Yices2Sort::compare(const Sort & s) const
 {
   shared_ptr<Yices2Sort> ys = std::static_pointer_cast<Yices2Sort>(s);
   return type == ys->type;


### PR DESCRIPTION
I noticed recently that the `Sort::compare` method takes a `const Sort`, when it could take a `const Sort &`. The reference is better because it avoids incrementing/decrementing the reference counter of the `Sort` (which is a `shared_ptr`). It's a minor change but had to be updated for all backends.

Note, this will need to be adjusted for other backends that haven't been merged yet @yoni206 and @lstuntz.