### PR TITLE
Finish old rename SortCon -> SortKind

### DIFF
--- a/include/sort.h
+++ b/include/sort.h
@@ -48,7 +48,7 @@ enum SortKind
   /** IMPORTANT: This must stay at the bottom.
       It's only use is for sizing the kind2str array
   */
-  NUM_SORT_CONS
+  NUM_SORT_KINDS
 };
 
 std::string to_string(SortKind);

--- a/src/logging_sort.cpp
+++ b/src/logging_sort.cpp
@@ -181,8 +181,7 @@ bool LoggingSort::compare(const Sort & s) const
     {
       throw NotImplementedException("LoggingSort::compare");
     }
-    case NUM_SORT_CONS:
-    {
+    case NUM_SORT_KINDS: {
       // null sorts should not be equal
       return false;
     }
@@ -190,7 +189,9 @@ bool LoggingSort::compare(const Sort & s) const
     {
       // this code should be unreachable
       throw SmtException(
-          "Hit default case in LoggingSort comparison -- missing a SortCon");
+          "Hit default case in LoggingSort comparison -- missing case for "
+          "SortKind: "
+          + smt::to_string(sk));
     }
   }
 }

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -36,7 +36,7 @@ const std::unordered_map<SortKind, std::string> sortkind2str(
 
 std::string to_string(SortKind sk)
 {
-  if (sk == NUM_SORT_CONS)
+  if (sk == NUM_SORT_KINDS)
   {
     return "null";
   }
@@ -56,7 +56,7 @@ std::ostream & operator<<(std::ostream & output, const Sort s)
 std::string AbsSort::to_string() const
 {
   SortKind sk = get_sort_kind();
-  if (sk == NUM_SORT_CONS)
+  if (sk == NUM_SORT_KINDS)
   {
     return "nullsort";
   }


### PR DESCRIPTION
A while ago, `SortKind` was named `SortCon`. There were a few areas where this rename didn't happen. This PR would fix that.