### PR TITLE
Allow getting uf sort from boolector term

### DIFF
--- a/btor/include/boolector_sort.h
+++ b/btor/include/boolector_sort.h
@@ -103,13 +103,45 @@ class BoolectorUFSort : public BoolectorSortBase
   BoolectorUFSort(Btor * b, BoolectorSort s, SortVec sorts, Sort sort)
       : BoolectorSortBase(FUNCTION, b, s),
         domain_sorts(sorts),
-        codomain_sort(sort){};
-  SortVec get_domain_sorts() const override { return domain_sorts; };
+        codomain_sort(sort),
+        complete(true){};
+
+  // this constructor is used by BoolectorTerm::get_sort()
+  // more info for flag complete below
+  BoolectorUFSort(Btor * b, BoolectorSort s, Sort codomain)
+      : BoolectorSortBase(FUNCTION, b, s),
+        codomain_sort(codomain),
+        complete(false)
+  {
+  }
+
+  SortVec get_domain_sorts() const override
+  {
+    if (complete)
+    {
+      return domain_sorts;
+    }
+    else
+    {
+      throw SmtException(
+          "Cannot recover domain from sort obtained with get_sort in "
+          "boolector");
+    }
+  };
+
   Sort get_codomain_sort() const override { return codomain_sort; };
 
  protected:
   SortVec domain_sorts;
   Sort codomain_sort;
+
+  // HACK boolector has no way of recovering domain sorts for arity > 1
+  // functions
+  //      still want to allow getting a sort, but that information is lost
+  //      if it's important, you can always use a logging solver
+  //      for now just set this flag to show that this is not a
+  //      "complete" sort representation
+  bool complete;
 
   friend class BoolectorSolver;
 };

--- a/btor/src/boolector_sort.cpp
+++ b/btor/src/boolector_sort.cpp
@@ -96,58 +96,7 @@ bool BoolectorSortBase::compare(const Sort & s) const
 {
   std::shared_ptr<BoolectorSortBase> bs =
       std::static_pointer_cast<BoolectorSortBase>(s);
-  if (sk != bs->get_sort_kind())
-  {
-    // Note: bool and bv will still be equal for boolector, because always
-    // create BV sort even if it's a bool
-    return false;
-  }
-
-  switch (sk)
-  {
-    case ARRAY:
-    {
-      return (get_indexsort() == bs->get_indexsort())
-             && (get_elemsort() == bs->get_elemsort());
-      break;
-    }
-    case BOOL:
-    case BV:
-    {
-      return get_width() == bs->get_width();
-      break;
-    }
-    case FUNCTION:
-    {
-      SortVec domain_sorts = get_domain_sorts();
-      SortVec bs_domain_sorts = bs->get_domain_sorts();
-
-      if (domain_sorts.size() != bs_domain_sorts.size())
-      {
-        return false;
-      }
-      else if (get_codomain_sort() != bs->get_codomain_sort())
-      {
-        return false;
-      }
-
-      bool res = true;
-
-      for (unsigned i = 0; i < domain_sorts.size(); ++i)
-      {
-        res &= (domain_sorts[i] == bs_domain_sorts[i]);
-      }
-
-      return res;
-      break;
-    }
-    default:
-    {
-      Unreachable();
-      break;
-    }
-  }
-  return false;
+  return (sort == bs->sort);
 }
 /* end BoolectorSolver implementation */
 

--- a/tests/unit/unit-sort.cpp
+++ b/tests/unit/unit-sort.cpp
@@ -78,6 +78,9 @@ TEST_P(UnitSortTests, SameSortDiffObj)
   EXPECT_EQ(bvsort->hash(), bvsort_2->hash());
   EXPECT_EQ(bvsort, bvsort_2);
 
+  Sort bvsort8 = s->make_sort(BV, 8);
+  EXPECT_NE(bvsort, bvsort8);
+
   Sort funsort_2 = s->make_sort(FUNCTION, { bvsort, bvsort_2 });
   EXPECT_EQ(funsort->hash(), funsort_2->hash());
   EXPECT_EQ(funsort, funsort_2);
@@ -196,5 +199,10 @@ TEST_P(UnitSortArithTests, SameSortDiffObj)
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSortTests,
                          UnitSortTests,
                          testing::ValuesIn(available_solver_configurations()));
+
+INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSortArithTests,
+                         UnitSortArithTests,
+                         testing::ValuesIn(filter_solver_configurations(
+                             { THEORY_INT, THEORY_REAL })));
 
 }  // namespace smt_tests


### PR DESCRIPTION
However there's still a restriction that you can't query for the domain sorts because there's no way to do that in boolector (except if arity is 1). It will return a `TupleSort` but there's no way to unpack it. One way around this would be to keep track of this info at the smt-switch level but this can already be done with a `LoggingSolver`.