### PR TITLE
Changing SMT-LIB constants to strings instead of macros

### DIFF
--- a/include/smtlib_utils.h
+++ b/include/smtlib_utils.h
@@ -17,19 +17,21 @@
 #pragma once
 
 /* string macros for the SMT-LIB commands */
-#define SET_OPTION_STR "set-option"
-#define SET_LOGIC_STR "set-logic"
-#define DECLARE_FUN_STR "declare-fun"
-#define DECLARE_SORT_STR "declare-sort"
-#define ASSERT_STR "assert"
-#define CHECK_SAT_STR "check-sat"
-#define CHECK_SAT_ASSUMING_STR "check-sat-assuming"
-#define GET_VALUE_STR "get-value"
-#define GET_UNSAT_ASSUMPTIONS_STR "get-unsat-assumptions"
-#define PUSH_STR "push"
-#define POP_STR "pop"
-#define RESET_ASSERTIONS_STR "reset-assertions"
-#define RESET_STR "reset"
-#define INTERPOLATION_GROUP_STR "interpolation-group"
-#define MSAT_GET_INTERPOLANT_STR "get-interpolant"
-#define CVC4_GET_INTERPOLANT_STR "get-interpol"
+const std::string SET_OPTION_STR = "set-option";
+const std::string SET_LOGIC_STR = "set-logic";
+const std::string DECLARE_FUN_STR = "declare-fun";
+const std::string DEFINE_FUN_STR = "define-fun";
+const std::string DECLARE_SORT_STR = "declare-sort";
+const std::string DEFINE_SORT_STR = "define-sort";
+const std::string ASSERT_STR = "assert";
+const std::string CHECK_SAT_STR = "check-sat";
+const std::string CHECK_SAT_ASSUMING_STR = "check-sat-assuming";
+const std::string GET_VALUE_STR = "get-value";
+const std::string GET_UNSAT_ASSUMPTIONS_STR = "get-unsat-assumptions";
+const std::string PUSH_STR = "push";
+const std::string POP_STR = "pop";
+const std::string RESET_ASSERTIONS_STR = "reset-assertions";
+const std::string RESET_STR = "reset";
+const std::string INTERPOLATION_GROUP_STR = "interpolation-group";
+const std::string MSAT_GET_INTERPOLANT_STR = "get-interpolant";
+const std::string CVC4_GET_INTERPOLANT_STR = "get-interpol";

--- a/include/smtlib_utils.h
+++ b/include/smtlib_utils.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-/* string macros for the SMT-LIB commands */
+/* string constants for the SMT-LIB commands */
 const std::string SET_OPTION_STR = "set-option";
 const std::string SET_LOGIC_STR = "set-logic";
 const std::string DECLARE_FUN_STR = "declare-fun";


### PR DESCRIPTION
Actually, the planned generic solver uses these macros as strings, not chars. So this PR makes them to be string constants instead of macros.