### PR TITLE
Header for Generic Sorts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ add_library(smt-switch "${SMT_SWITCH_LIB_TYPE}"
   "${PROJECT_SOURCE_DIR}/src/logging_sort.cpp"
   "${PROJECT_SOURCE_DIR}/src/logging_term.cpp"
   "${PROJECT_SOURCE_DIR}/src/logging_solver.cpp"
-  "${PROJECT_SOURCE_DIR}/include/generic_sort.h"
   "${PROJECT_SOURCE_DIR}/src/printing_solver.cpp"
   "${PROJECT_SOURCE_DIR}/include/smtlib_utils.h"
   "${PROJECT_SOURCE_DIR}/src/utils.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(smt-switch "${SMT_SWITCH_LIB_TYPE}"
   "${PROJECT_SOURCE_DIR}/src/logging_sort.cpp"
   "${PROJECT_SOURCE_DIR}/src/logging_term.cpp"
   "${PROJECT_SOURCE_DIR}/src/logging_solver.cpp"
+  "${PROJECT_SOURCE_DIR}/include/generic_sort.h"
   "${PROJECT_SOURCE_DIR}/src/printing_solver.cpp"
   "${PROJECT_SOURCE_DIR}/include/smtlib_utils.h"
   "${PROJECT_SOURCE_DIR}/src/utils.cpp")

--- a/include/generic_sort.h
+++ b/include/generic_sort.h
@@ -56,7 +56,7 @@ class GenericSort : public AbsSort
         "get_width not implemented by GenericSort");
   }
 
-  uint64_t get_arity() const override
+  size_t get_arity() const override
   {
     throw NotImplementedException(
         "get_width not implemented by GenericSort");

--- a/include/generic_sort.h
+++ b/include/generic_sort.h
@@ -1,0 +1,190 @@
+/*********************                                                        */
+/*! \file generic_sort.h
+** \verbatim
+** Top contributors (to current version):
+**   Yoni Zohar
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Class that represents a sort in generic solvers
+**        
+**
+**/
+
+#pragma once
+
+#include "exceptions.h"
+#include "smt_defs.h"
+#include "sort.h"
+#include <functional>
+namespace smt {
+
+/* Helper functions for creating generic sorts */
+Sort make_uninterpreted_generic_sort(std::string name, uint64_t arity);
+Sort make_uninterpreted_generic_sort(Sort sort_cons, const SortVec& sorts);
+Sort make_generic_sort(SortKind sk);
+Sort make_generic_sort(SortKind sk, uint64_t width);
+Sort make_generic_sort(SortKind sk, Sort sort1);
+Sort make_generic_sort(SortKind sk, Sort sort1, Sort sort2);
+Sort make_generic_sort(SortKind sk, Sort sort1, Sort sort2, Sort sort3);
+Sort make_generic_sort(SortKind sk, SortVec sorts);
+
+/* smtlib representation of sort kinds */
+std::string to_smtlib(SortKind);
+
+/** \class GenericSort
+ *  An abstract class for generic Sorts
+ */
+class GenericSort : public AbsSort
+{
+ public:
+  GenericSort(SortKind sk); 
+  virtual ~GenericSort();
+  SortKind get_sort_kind() const override;
+  bool compare(const Sort & s) const override;
+
+  /** The following functions are 
+   *   implemented by sub-classes 
+   */
+
+  uint64_t get_width() const override
+  {
+    throw NotImplementedException(
+        "get_width not implemented by GenericSort");
+  }
+
+  uint64_t get_arity() const override
+  {
+    throw NotImplementedException(
+        "get_width not implemented by GenericSort");
+  }
+
+  Sort get_indexsort() const override
+  {
+    throw NotImplementedException(
+        "get_indexsort not implemented by GenericSort");
+  }
+
+  Sort get_elemsort() const override
+  {
+    throw NotImplementedException(
+        "get_elemsort not implemented by GenericSort");
+  }
+
+  SortVec get_domain_sorts() const override
+  {
+    throw NotImplementedException(
+        "get_domain_sorts not implemented by GenericSort");
+  }
+
+  Sort get_codomain_sort() const override
+  {
+    throw NotImplementedException(
+        "get_codomain_sort not implemented by GenericSort");
+  }
+
+  std::string get_uninterpreted_name() const override
+  {
+    throw NotImplementedException(
+        "get_uninterpreted_name not implemented by GenericSort");
+  }
+
+  std::vector<Sort> get_uninterpreted_param_sorts() const override 
+  {
+    throw NotImplementedException(
+        "get_uninterpreted_param_sorts not implemented by GenericSort");
+  }
+
+  Datatype get_datatype() const override
+  {
+    throw NotImplementedException(
+        "get_datatype not implemented by GenericSort");
+  }
+  
+  // hash computed via std::string hash
+  std::size_t hash() const override;
+
+  // A string representation of a sort
+  std::string to_string() const override;
+
+ protected:
+  // internal function to compute
+  // the string representation of a sort
+  std::string compute_string() const;
+
+  // The underlying SortKind of the GenericSort
+  SortKind sk;
+
+  // strings hash function, to be used for hash()
+  std::hash<std::string> str_hash;
+
+  // So GenericSolver can access protected members:
+  friend class GenericSolver;
+};
+
+/** 
+ * sub-classes of specific kinds of sorts
+ */
+
+class BVGenericSort : public GenericSort
+{
+ public:
+  BVGenericSort(uint64_t width);
+  ~BVGenericSort();
+
+  uint64_t get_width() const override;
+
+ protected:
+  uint64_t width;
+};
+
+class ArrayGenericSort : public GenericSort
+{
+ public:
+  ArrayGenericSort(Sort idxsort, Sort esort);
+  ~ArrayGenericSort();
+
+  Sort get_indexsort() const override;
+  Sort get_elemsort() const override;
+
+ protected:
+  Sort indexsort;
+  Sort elemsort;
+};
+
+class FunctionGenericSort : public GenericSort
+{
+ public:
+  FunctionGenericSort(SortVec sorts, Sort rsort);
+  ~FunctionGenericSort();
+
+  SortVec get_domain_sorts() const override;
+  Sort get_codomain_sort() const override;
+
+ protected:
+  SortVec domain_sorts;
+  Sort codomain_sort;
+};
+
+class UninterpretedGenericSort : public GenericSort
+{
+ public:
+  UninterpretedGenericSort(std::string n, uint64_t a);
+  UninterpretedGenericSort(Sort sort_cons,
+                           const SortVec & sorts);
+  ~UninterpretedGenericSort();
+
+  std::string get_uninterpreted_name() const override;
+  size_t get_arity() const override;
+  SortVec get_uninterpreted_param_sorts() const override;
+
+ protected:
+  std::string name;
+  uint64_t arity;
+  SortVec param_sorts;  
+};
+
+}  // namespace smt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,6 +138,11 @@ target_link_libraries(test_logging_solver gtest_main)
 target_link_libraries(test_logging_solver test-deps)
 add_test(NAME test_logging_solver_test COMMAND test_logging_solver)
 
+add_executable(test_generic_solver "${PROJECT_SOURCE_DIR}/tests/test-generic-solver.cpp")
+target_link_libraries(test_generic_solver gtest_main)
+target_link_libraries(test_generic_solver test-deps)
+add_test(NAME test_generic_solver_test COMMAND test_generic_solver)
+
 add_executable(test-term-translation "${PROJECT_SOURCE_DIR}/tests/test-term-translation.cpp")
 target_link_libraries(test-term-translation gtest_main)
 target_link_libraries(test-term-translation test-deps)

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -1,0 +1,42 @@
+/*********************                                                        */
+/*! \file cvc4-printinh.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Yoni Zohar
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief
+**
+**
+**/
+#include <fstream>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <array>
+#include <iostream>
+#include <memory>
+#include <vector>
+#include <sstream>
+#include "assert.h"
+
+// note: this file depends on the CMake build infrastructure
+// specifically defined macros
+// it cannot be compiled outside of the build
+#include "test-utils.h"
+
+#include "cvc4_factory.h"
+#include "generic_sort.h"
+#include "smt.h"
+
+using namespace smt;
+using namespace std;
+
+int main()
+{
+  return 0;
+}


### PR DESCRIPTION
This PR introduces a header file (no implementations) for generic sorts, that will be used be generic solvers.
It follows a similar structure to that of a logging sort.

I've also included an empty test file that includes `generic_sort.h`, as otherwise the header is not compiled and errors are not detected. The test file will be filled gradually as implementations are added.

~~The `cmake` file points to the header file. This will be changed once implementations are added.~~
Nothing is added to the `cmake` files, as the header file is compiled thanks to its inclusion in the test.
