### PR TITLE
Add method to get unique Term ID

### DIFF
--- a/btor/include/boolector_term.h
+++ b/btor/include/boolector_term.h
@@ -75,6 +75,7 @@ class BoolectorTerm : public AbsTerm
   BoolectorTerm(Btor * b, BoolectorNode * n);
   ~BoolectorTerm();
   std::size_t hash() const override;
+  std::size_t get_id() const override;
   bool compare(const Term & absterm) const override;
   Op get_op() const override;
   Sort get_sort() const override;

--- a/btor/src/boolector_term.cpp
+++ b/btor/src/boolector_term.cpp
@@ -195,8 +195,11 @@ BoolectorTerm::~BoolectorTerm()
   boolector_release(btor, node);
 }
 
-// TODO: check if this is okay -- probably not
+// BoolectorNode * -> id
+
 std::size_t BoolectorTerm::hash() const { return (std::size_t)node; };
+
+std::size_t BoolectorTerm::get_id() const { return (std::size_t)node; };
 
 bool BoolectorTerm::compare(const Term & absterm) const
 {

--- a/cvc4/include/cvc4_term.h
+++ b/cvc4/include/cvc4_term.h
@@ -68,6 +68,7 @@ namespace smt {
     CVC4Term(CVC4::api::Term t) : term(t) {};
     ~CVC4Term() {};
     std::size_t hash() const override;
+    std::size_t get_id() const override;
     bool compare(const Term & absterm) const override;
     Op get_op() const override;
     Sort get_sort() const override;

--- a/cvc4/src/cvc4_term.cpp
+++ b/cvc4/src/cvc4_term.cpp
@@ -185,6 +185,8 @@ std::size_t CVC4Term::hash() const
   return termhash(term);
 }
 
+std::size_t CVC4Term::get_id() const { return term.getId(); }
+
 bool CVC4Term::compare(const Term & absterm) const
 {
   std::shared_ptr<CVC4Term> other =

--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -97,6 +97,11 @@ class LoggingSolver : public AbsSmtSolver
   // after a call to get_unsat_core
   std::unique_ptr<UnorderedTermMap> assumption_cache;
 
+  // NOTE this is a little ugly, but this needs to be incremented
+  // in const methods (make_term), so it is marked mutable
+  // this was better than making them non-const because most solvers
+  // can respect the const-ness of those make_term functions
+  mutable size_t next_term_id;  ///< used to give LoggingTerms a unique id
 };
 
 }  // namespace smt

--- a/include/logging_term.h
+++ b/include/logging_term.h
@@ -25,16 +25,18 @@ namespace smt {
 class LoggingTerm : public AbsTerm
 {
  public:
-  LoggingTerm(Term t, Sort s, Op o, TermVec c);
+  LoggingTerm(Term t, Sort s, Op o, TermVec c, size_t id);
   // this one is for making symbols
   // if passed with true, sets is_sym true
   // otherwise sets is_param true
   // only symbols and parameters have names
-  LoggingTerm(Term t, Sort s, Op o, TermVec c, std::string r, bool is_sym);
+  LoggingTerm(
+      Term t, Sort s, Op o, TermVec c, std::string r, bool is_sym, size_t id);
   virtual ~LoggingTerm();
 
   // implemented
 
+  std::size_t get_id() const override;
   /** Returns true iff the underlying term AND sort are equivalent
    *  @param t the term to compare with (assumed to be LoggingTerm)
    *  @return true iff the underlying term and sort match t
@@ -63,6 +65,7 @@ class LoggingTerm : public AbsTerm
   std::string repr;
   bool is_sym;
   bool is_par;
+  size_t id_;  ///< unique id for this term
 
   // So LoggingSolver can access protected members:
   friend class LoggingSolver;

--- a/include/term.h
+++ b/include/term.h
@@ -93,8 +93,31 @@ class AbsTerm
   virtual std::string print_value_as(SortKind sk) = 0;
 };
 
-bool operator==(const Term& t1, const Term& t2);
-bool operator!=(const Term & t1, const Term & t2);
+inline bool operator==(const Term & t1, const Term & t2)
+{
+  return t1->compare(t2);
+}
+inline bool operator!=(const Term & t1, const Term & t2)
+{
+  return !t1->compare(t2);
+}
+inline bool operator<(const Term & t1, const Term & t2)
+{
+  return t1->get_id() < t2->get_id();
+}
+inline bool operator>(const Term & t1, const Term & t2)
+{
+  return t1->get_id() > t2->get_id();
+}
+inline bool operator<=(const Term & t1, const Term & t2)
+{
+  return t1->get_id() <= t2->get_id();
+}
+inline bool operator>=(const Term & t1, const Term & t2)
+{
+  return t1->get_id() >= t2->get_id();
+}
+
 std::ostream& operator<<(std::ostream& output, const Term t);
 
 // term iterators

--- a/include/term.h
+++ b/include/term.h
@@ -37,7 +37,10 @@ class AbsTerm
  public:
   AbsTerm(){};
   virtual ~AbsTerm(){};
+  /** Returns a hash for this term */
   virtual std::size_t hash() const = 0;
+  /** Returns a unique id for this term */
+  virtual std::size_t get_id() const = 0;
   /* Should return true iff the terms are identical */
   virtual bool compare(const Term& absterm) const = 0;
   // Term methods

--- a/msat/include/msat_term.h
+++ b/msat/include/msat_term.h
@@ -66,6 +66,7 @@ class MsatTerm : public AbsTerm
   };
   ~MsatTerm(){};
   std::size_t hash() const override;
+  std::size_t get_id() const override;
   bool compare(const Term & absterm) const override;
   Op get_op() const override;
   Sort get_sort() const override;

--- a/msat/src/msat_term.cpp
+++ b/msat/src/msat_term.cpp
@@ -211,7 +211,9 @@ bool MsatTermIter::equal(const TermIterBase & other) const
 
 // MsatTerm implementation
 
-size_t MsatTerm::hash() const
+size_t MsatTerm::hash() const { return get_id(); }
+
+size_t MsatTerm::get_id() const
 {
   if (!is_uf)
   {

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -44,7 +44,8 @@ LoggingSolver::LoggingSolver(SmtSolver s)
     : AbsSmtSolver(s->get_solver_enum()),
       wrapped_solver(s),
       hashtable(new TermHashTable()),
-      assumption_cache(new UnorderedTermMap())
+      assumption_cache(new UnorderedTermMap()),
+      next_term_id(0)
 {
 }
 
@@ -169,8 +170,8 @@ Term LoggingSolver::make_term(bool b) const
 {
   Term wrapped_res = wrapped_solver->make_term(b);
   Sort boolsort = make_logging_sort(BOOL, wrapped_res->get_sort());
-  Term res =
-      std::make_shared<LoggingTerm>(wrapped_res, boolsort, Op(), TermVec{});
+  Term res = std::make_shared<LoggingTerm>(
+      wrapped_res, boolsort, Op(), TermVec{}, next_term_id);
 
   // check hash table
   // lookup modifies term in place and returns true if it's a known term
@@ -179,6 +180,7 @@ Term LoggingSolver::make_term(bool b) const
   {
     // this is the first time this term was created
     hashtable->insert(res);
+    next_term_id++;
   }
 
   return res;
@@ -188,7 +190,8 @@ Term LoggingSolver::make_term(int64_t i, const Sort & sort) const
 {
   shared_ptr<LoggingSort> lsort = static_pointer_cast<LoggingSort>(sort);
   Term wrapped_res = wrapped_solver->make_term(i, lsort->wrapped_sort);
-  Term res = std::make_shared<LoggingTerm>(wrapped_res, sort, Op(), TermVec{});
+  Term res = std::make_shared<LoggingTerm>(
+      wrapped_res, sort, Op(), TermVec{}, next_term_id);
 
   // check hash table
   // lookup modifies term in place and returns true if it's a known term
@@ -197,6 +200,7 @@ Term LoggingSolver::make_term(int64_t i, const Sort & sort) const
   {
     // this is the first time this term was created
     hashtable->insert(res);
+    next_term_id++;
   }
 
   return res;
@@ -208,7 +212,8 @@ Term LoggingSolver::make_term(const string name,
 {
   shared_ptr<LoggingSort> lsort = static_pointer_cast<LoggingSort>(sort);
   Term wrapped_res = wrapped_solver->make_term(name, lsort->wrapped_sort, base);
-  Term res = std::make_shared<LoggingTerm>(wrapped_res, sort, Op(), TermVec{});
+  Term res = std::make_shared<LoggingTerm>(
+      wrapped_res, sort, Op(), TermVec{}, next_term_id);
 
   // check hash table
   // lookup modifies term in place and returns true if it's a known term
@@ -217,6 +222,7 @@ Term LoggingSolver::make_term(const string name,
   {
     // this is the first time this term was created
     hashtable->insert(res);
+    next_term_id++;
   }
 
   return res;
@@ -237,8 +243,8 @@ Term LoggingSolver::make_term(const Term & val, const Sort & sort) const
         + sort->to_string());
   }
   // the constant value must be the child
-  Term res =
-      std::make_shared<LoggingTerm>(wrapped_res, sort, Op(), TermVec{ val });
+  Term res = std::make_shared<LoggingTerm>(
+      wrapped_res, sort, Op(), TermVec{ val }, next_term_id);
 
   // check hash table
   // lookup modifies term in place and returns true if it's a known term
@@ -247,6 +253,7 @@ Term LoggingSolver::make_term(const Term & val, const Sort & sort) const
   {
     // this is the first time this term was created
     hashtable->insert(res);
+    next_term_id++;
   }
 
   return res;
@@ -258,7 +265,7 @@ Term LoggingSolver::make_symbol(const string name, const Sort & sort)
   Term wrapped_sym = wrapped_solver->make_symbol(name, lsort->wrapped_sort);
   // bool true means it's a symbol
   Term res = std::make_shared<LoggingTerm>(
-      wrapped_sym, sort, Op(), TermVec{}, name, true);
+      wrapped_sym, sort, Op(), TermVec{}, name, true, next_term_id);
 
   // check hash table
   // lookup modifies term in place and returns true if it's a known term
@@ -267,6 +274,7 @@ Term LoggingSolver::make_symbol(const string name, const Sort & sort)
   {
     // this is the first time this term was created
     hashtable->insert(res);
+    next_term_id++;
   }
 
   return res;
@@ -278,7 +286,7 @@ Term LoggingSolver::make_param(const string name, const Sort & sort)
   Term wrapped_param = wrapped_solver->make_param(name, lsort->wrapped_sort);
   // bool false means it's not a symbol
   Term res = std::make_shared<LoggingTerm>(
-      wrapped_param, sort, Op(), TermVec{}, name, false);
+      wrapped_param, sort, Op(), TermVec{}, name, false, next_term_id);
 
   // check hash table
   // lookup modifies term in place and returns true if it's a known term
@@ -287,6 +295,7 @@ Term LoggingSolver::make_param(const string name, const Sort & sort)
   {
     // this is the first time this term was created
     hashtable->insert(res);
+    next_term_id++;
   }
 
   return res;
@@ -302,7 +311,7 @@ Term LoggingSolver::make_term(const Op op, const Term & t) const
   assert(hashtable->contains(t));
 
   Term res = std::make_shared<LoggingTerm>(
-      wrapped_res, res_logging_sort, op, TermVec{ t });
+      wrapped_res, res_logging_sort, op, TermVec{ t }, next_term_id);
 
   // check hash table
   // lookup modifies term in place and returns true if it's a known term
@@ -311,6 +320,7 @@ Term LoggingSolver::make_term(const Op op, const Term & t) const
   {
     // this is the first time this term was created
     hashtable->insert(res);
+    next_term_id++;
   }
 
   return res;
@@ -331,9 +341,8 @@ Term LoggingSolver::make_term(const Op op,
   assert(hashtable->contains(t1));
   assert(hashtable->contains(t2));
 
-  Term res(
-      new LoggingTerm(wrapped_res, res_logging_sort, op, TermVec{ t1, t2 }));
-
+  Term res = std::make_shared<LoggingTerm>(
+      wrapped_res, res_logging_sort, op, TermVec({ t1, t2 }), next_term_id);
   // check hash table
   // lookup modifies term in place and returns true if it's a known term
   // i.e. returns existing term and destroying the unnecessary new one
@@ -341,6 +350,7 @@ Term LoggingSolver::make_term(const Op op,
   {
     // this is the first time this term was created
     hashtable->insert(res);
+    next_term_id++;
   }
 
   return res;
@@ -365,7 +375,7 @@ Term LoggingSolver::make_term(const Op op,
   assert(hashtable->contains(t3));
 
   Term res = std::make_shared<LoggingTerm>(
-      wrapped_res, res_logging_sort, op, TermVec{ t1, t2, t3 });
+      wrapped_res, res_logging_sort, op, TermVec{ t1, t2, t3 }, next_term_id);
 
   // check hash table
   // lookup modifies term in place and returns true if it's a known term
@@ -374,6 +384,7 @@ Term LoggingSolver::make_term(const Op op,
   {
     // this is the first time this term was created
     hashtable->insert(res);
+    next_term_id++;
   }
 
   return res;
@@ -394,8 +405,8 @@ Term LoggingSolver::make_term(const Op op, const TermVec & terms) const
   // Note: for convenience there's a version of compute_sort that takes terms
   // since these are already in a vector, just let it unpack the sorts
   Sort res_logging_sort = compute_sort(op, this, terms);
-  Term res =
-      std::make_shared<LoggingTerm>(wrapped_res, res_logging_sort, op, terms);
+  Term res = std::make_shared<LoggingTerm>(
+      wrapped_res, res_logging_sort, op, terms, next_term_id);
 
   // check hash table
   // lookup modifies term in place and returns true if it's a known term
@@ -404,6 +415,7 @@ Term LoggingSolver::make_term(const Op op, const TermVec & terms) const
   {
     // this is the first time this term was created
     hashtable->insert(res);
+    next_term_id++;
   }
 
   return res;
@@ -425,7 +437,17 @@ Term LoggingSolver::get_value(const Term & t) const
   {
     Term wrapped_val = wrapped_solver->get_value(lt->wrapped_term);
     res = std::make_shared<LoggingTerm>(
-        wrapped_val, t->get_sort(), Op(), TermVec{});
+        wrapped_val, t->get_sort(), Op(), TermVec{}, next_term_id);
+
+    // check hash table
+    // lookup modifies term in place and returns true if it's a known term
+    // i.e. returns existing term and destroying the unnecessary new one
+    if (!hashtable->lookup(res))
+    {
+      // this is the first time this term was created
+      hashtable->insert(res);
+      next_term_id++;
+    }
   }
   else
   {
@@ -442,15 +464,6 @@ Term LoggingSolver::get_value(const Term & t) const
     {
       res = make_term(Store, res, elem.first, elem.second);
     }
-  }
-
-  // check hash table
-  // lookup modifies term in place and returns true if it's a known term
-  // i.e. returns existing term and destroying the unnecessary new one
-  if (!hashtable->lookup(res))
-  {
-    // this is the first time this term was created
-    hashtable->insert(res);
   }
 
   return res;
@@ -495,9 +508,8 @@ UnorderedTermMap LoggingSolver::get_array_values(const Term & arr,
           "const base for multidimensional array not implemented in "
           "LoggingSolver");
     }
-    out_const_base = Term(
-        new LoggingTerm(wrapped_out_const_base, elemsort, Op(), TermVec{}));
-
+    out_const_base = std::make_shared<LoggingTerm>(
+        wrapped_out_const_base, elemsort, Op(), TermVec{}, next_term_id);
     // check hash table
     // lookup modifies term in place and returns true if it's a known term
     // i.e. returns existing term and destroys the unnecessary new one
@@ -505,6 +517,7 @@ UnorderedTermMap LoggingSolver::get_array_values(const Term & arr,
     {
       // this is the first time this term was created
       hashtable->insert(out_const_base);
+      next_term_id++;
     }
   }
 
@@ -516,18 +529,22 @@ UnorderedTermMap LoggingSolver::get_array_values(const Term & arr,
     Assert(elem.first->is_value());
     Assert(elem.second->is_value());
 
-    idx = std::make_shared<LoggingTerm>(elem.first, idxsort, Op(), TermVec{});
+    idx = std::make_shared<LoggingTerm>(
+        elem.first, idxsort, Op(), TermVec{}, next_term_id);
     if (!hashtable->lookup(idx))
     {
       // this is the first time this term was created
       hashtable->insert(idx);
+      next_term_id++;
     }
 
-    val = std::make_shared<LoggingTerm>(elem.second, elemsort, Op(), TermVec{});
+    val = std::make_shared<LoggingTerm>(
+        elem.second, elemsort, Op(), TermVec{}, next_term_id);
     if (!hashtable->lookup(val))
     {
       // this is the first time this term was created
       hashtable->insert(val);
+      next_term_id++;
     }
 
     assignments[idx] = val;

--- a/src/logging_term.cpp
+++ b/src/logging_term.cpp
@@ -25,25 +25,36 @@ namespace smt {
 
 /* LoggingTerm */
 
-LoggingTerm::LoggingTerm(Term t, Sort s, Op o, TermVec c)
-    : wrapped_term(t), sort(s), op(o), children(c), is_sym(false), is_par(false)
+LoggingTerm::LoggingTerm(Term t, Sort s, Op o, TermVec c, size_t id)
+    : wrapped_term(t),
+      sort(s),
+      op(o),
+      children(c),
+      is_sym(false),
+      is_par(false),
+      id_(id)
 {
 }
 
-LoggingTerm::LoggingTerm(Term t, Sort s, Op o, TermVec c, string r, bool is_sym)
+LoggingTerm::LoggingTerm(
+    Term t, Sort s, Op o, TermVec c, string r, bool is_sym, size_t id)
     : wrapped_term(t),
       sort(s),
       op(o),
       children(c),
       repr(r),
       is_sym(is_sym),
-      is_par(!is_sym)
+      is_par(!is_sym),
+      id_(id)
 {
 }
 
 LoggingTerm::~LoggingTerm() {}
 
 // implemented
+
+size_t LoggingTerm::get_id() const { return id_; }
+
 bool LoggingTerm::compare(const Term & t) const
 {
   // This methods compares two LoggingTerms

--- a/src/term.cpp
+++ b/src/term.cpp
@@ -18,10 +18,6 @@
 
 namespace smt {
 
-bool operator==(const Term & t1, const Term & t2) { return t1->compare(t2); }
-
-bool operator!=(const Term & t1, const Term & t2) { return !t1->compare(t2); }
-
 std::ostream & operator<<(std::ostream & output, const Term t)
 {
   output << t->to_string();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -173,6 +173,11 @@ target_link_libraries(unit-substitute gtest_main)
 target_link_libraries(unit-substitute test-deps)
 add_test(NAME unit-substitute_test COMMAND unit-substitute)
 
+add_executable(unit-term-id "${PROJECT_SOURCE_DIR}/tests/unit/unit-term-id.cpp")
+target_link_libraries(unit-term-id gtest_main)
+target_link_libraries(unit-term-id test-deps)
+add_test(NAME unit-term-id_test COMMAND unit-term-id)
+
 add_executable(unit-reset-assertions "${PROJECT_SOURCE_DIR}/tests/unit/unit-reset-assertions.cpp")
 target_link_libraries(unit-reset-assertions gtest_main)
 target_link_libraries(unit-reset-assertions test-deps)

--- a/tests/unit/unit-term-id.cpp
+++ b/tests/unit/unit-term-id.cpp
@@ -1,0 +1,86 @@
+
+/*********************                                           */
+/*! \file unit-term-id.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Unit tests for Term unique ids
+**
+**
+**/
+
+#include <utility>
+#include <vector>
+
+#include "available_solvers.h"
+#include "gtest/gtest.h"
+#include "smt.h"
+
+using namespace smt;
+using namespace std;
+
+namespace smt_tests {
+
+class UnitTermIdTests
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<SolverConfiguration>
+{
+ protected:
+  void SetUp() override
+  {
+    s = create_solver(GetParam());
+    s->set_opt("produce-models", "true");
+    s->set_opt("incremental", "true");
+
+    boolsort = s->make_sort(BOOL);
+    bvsort = s->make_sort(BV, 4);
+    a = s->make_symbol("a", boolsort);
+    b = s->make_symbol("b", boolsort);
+    x = s->make_symbol("x", bvsort);
+    y = s->make_symbol("y", bvsort);
+    one = s->make_term(1, bvsort);
+  }
+  SmtSolver s;
+  Sort boolsort, bvsort;
+  Term a, b, x, y, one;
+};
+
+TEST_P(UnitTermIdTests, BasicTest)
+{
+  EXPECT_EQ(a->get_id(), a->get_id());
+  EXPECT_EQ(x->get_id(), x->get_id());
+
+  EXPECT_NE(a->get_id(), b->get_id());
+  EXPECT_NE(x->get_id(), y->get_id());
+  EXPECT_NE(x->get_id(), one->get_id());
+
+  Term a_and_b = s->make_term(And, a, b);
+  EXPECT_NE(b->get_id(), a_and_b->get_id());
+
+  Term a_and_b_2 = s->make_term(And, a, b);
+  EXPECT_EQ(a_and_b->get_id(), a_and_b_2->get_id());
+
+  Term xp1 = s->make_term(BVAdd, x, one);
+  EXPECT_NE(x->get_id(), xp1->get_id());
+
+  Term xp1_2 = s->make_term(BVAdd, x, one);
+  EXPECT_EQ(xp1->get_id(), xp1_2->get_id());
+
+  Term yp1 = s->make_term(BVAdd, y, one);
+  EXPECT_NE(y->get_id(), yp1->get_id());
+
+  Term yp1_2 = s->make_term(BVAdd, y, one);
+  EXPECT_EQ(yp1->get_id(), yp1->get_id());
+}
+
+INSTANTIATE_TEST_SUITE_P(ParameterizedUnitTermIdTests,
+                         UnitTermIdTests,
+                         testing::ValuesIn(available_solver_configurations()));
+
+}  // namespace smt_tests

--- a/tests/unit/unit-term-id.cpp
+++ b/tests/unit/unit-term-id.cpp
@@ -60,6 +60,13 @@ TEST_P(UnitTermIdTests, BasicTest)
   EXPECT_NE(x->get_id(), y->get_id());
   EXPECT_NE(x->get_id(), one->get_id());
 
+  Term second_one = s->make_term(1, bvsort);
+  Term two = s->make_term(2, bvsort);
+  EXPECT_EQ(one->get_id(), second_one->get_id());
+  EXPECT_EQ(one, second_one);
+  EXPECT_NE(one->get_id(), two->get_id());
+  EXPECT_NE(one, two);
+
   Term a_and_b = s->make_term(And, a, b);
   EXPECT_NE(b->get_id(), a_and_b->get_id());
 

--- a/yices2/include/yices2_term.h
+++ b/yices2/include/yices2_term.h
@@ -59,6 +59,7 @@ class Yices2Term : public AbsTerm
   Yices2Term(term_t t, bool is_fun) : term(t), is_function(is_fun){};
   ~Yices2Term(){};
   std::size_t hash() const override;
+  std::size_t get_id() const override;
   bool compare(const Term & absterm) const override;
   Op get_op() const override;
   Sort get_sort() const override;

--- a/yices2/src/yices2_term.cpp
+++ b/yices2/src/yices2_term.cpp
@@ -222,6 +222,8 @@ size_t Yices2Term::hash() const
   return term;
 }
 
+size_t Yices2Term::get_id() const { return term; }
+
 bool Yices2Term::compare(const Term & absterm) const
 {
   shared_ptr<Yices2Term> yterm = std::static_pointer_cast<Yices2Term>(absterm);


### PR DESCRIPTION
All solvers that I'm aware of support getting a unique id for a term. For many solvers, there is no distinction between the hash and the unique id, but in smt-switch we will have both to support solvers where there is a difference.