### PR TITLE
get_ops oracle

### DIFF
--- a/include/ops.h
+++ b/include/ops.h
@@ -156,7 +156,7 @@ std::ostream& operator<<(std::ostream& output, const Op o);
 // defining hash for old compilers
 namespace std
 {
-  // specialize the hash template
+  // specialize the hash template for PrimOp
   template<>
     struct hash<smt::PrimOp>
     {
@@ -166,12 +166,13 @@ namespace std
       }
     };
 
-  // specialize the hash template
+  // specialize the hash template for Op
   template<>
     struct hash<smt::Op>
     {
       size_t operator()(const smt::Op o) const
       {
+        // The hash function for op computes the string hash
         std::hash<std::string> str_hash;
         return str_hash(o.to_string());
       }

--- a/include/ops.h
+++ b/include/ops.h
@@ -19,6 +19,8 @@
 #include <iostream>
 #include <string>
 #include <utility>
+#include <unordered_set>
+#include <functional>
 
 namespace smt {
 
@@ -136,6 +138,7 @@ struct Op
   uint64_t idx0;
   uint64_t idx1;
 };
+using UnorderedOpSet = std::unordered_set<Op>;
 
 /** Looks up the expected arity of a PrimOp
  *  @return a tuple with the minimum and maximum
@@ -160,6 +163,17 @@ namespace std
       size_t operator()(const smt::PrimOp o) const
       {
         return static_cast<std::size_t>(o);
+      }
+    };
+
+  // specialize the hash template
+  template<>
+    struct hash<smt::Op>
+    {
+      size_t operator()(const smt::Op o) const
+      {
+        std::hash<std::string> str_hash;
+        return str_hash(o.to_string());
       }
     };
 }

--- a/include/utils.h
+++ b/include/utils.h
@@ -86,6 +86,8 @@ void get_free_symbolic_consts(const smt::Term & term,
 
 void get_free_symbols(const smt::Term & term, smt::UnorderedTermSet & out);
 
+void get_ops(const smt::Term & term, smt::UnorderedOpSet & out);
+
 
 // -----------------------------------------------------------------------------
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -147,6 +147,7 @@ void get_ops(const smt::Term & term,
     if (visited.find(t) == visited.end()) {
       visited.insert(t);
       Op op = t->get_op();
+      // Only add non-null operators to the set
       if (!op.is_null()) {
         out.insert(t->get_op());
         // add children to queue

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -134,6 +134,31 @@ void get_matching_terms(const smt::Term & term,
   }
 }
 
+void get_ops(const smt::Term & term,
+                    smt::UnorderedOpSet & out)
+{
+  smt::TermVec to_visit({ term });
+  smt::UnorderedTermSet visited;
+
+  smt::Term t;
+  while (to_visit.size()) {
+    t = to_visit.back();
+    to_visit.pop_back();
+    if (visited.find(t) == visited.end()) {
+      visited.insert(t);
+      Op op = t->get_op();
+      if (!op.is_null()) {
+        out.insert(t->get_op());
+        // add children to queue
+        for (auto tt : t) {
+          to_visit.push_back(tt);
+        }
+      }
+    }
+  }
+}
+
+
 void get_free_symbolic_consts(const smt::Term & term,
                               smt::UnorderedTermSet & out)
 {

--- a/tests/unit/unit-util.cpp
+++ b/tests/unit/unit-util.cpp
@@ -151,5 +151,4 @@ INSTANTIATE_TEST_SUITE_P(ParameterizedUnitUtilTests,
                          UnitUtilTests,
                          testing::ValuesIn(filter_solver_configurations({ TERMITER })));
 
-
 }  // namespace smt_tests

--- a/tests/unit/unit-util.cpp
+++ b/tests/unit/unit-util.cpp
@@ -105,12 +105,17 @@ TEST_P(UnitUtilTests, DisjunctivePartition)
 TEST_P(UnitUtilTests, Oracles)
 {
   SolverConfiguration c = GetParam();
+  // We only test get_ops and get_free_symbolic_consts
+  // on logging solvers different from BTOR.
+  // We exclude BTOR because we test integers.
+  // We only include logging solvers because otherwise
+  // the operators and symbols might change due to internal rewrites.
   if (c.is_logging_solver && c.solver_enum != BTOR) {
     Sort int_sort = s->make_sort(INT);
     Sort bv_sort = s->make_sort(BV, 4);
     Term int1 = s->make_symbol("int1", int_sort);
     Term bv1 = s->make_symbol("bv1", bv_sort);
-    
+
     Term term1 = s->make_term(Plus, int1, int1);
     term1 = s->make_term(Mult, term1, int1);
     term1 = s->make_term(Lt, term1, int1);
@@ -120,12 +125,12 @@ TEST_P(UnitUtilTests, Oracles)
     term2 = s->make_term(BVUlt, term2, bv1);
 
     Term term = s->make_term(And, term1, term2);
-  
+
     UnorderedTermSet expected_symbols, concrete_symbols;
     expected_symbols.insert(int1);
     expected_symbols.insert(bv1);
     get_free_symbolic_consts(term, concrete_symbols);
-  
+
     UnorderedOpSet expected_ops, concrete_ops;
     expected_ops.insert(Op(And));
     expected_ops.insert(Op(Plus));


### PR DESCRIPTION
This PR introduces a `get_ops` function to `utils`, that computes the set of operators in a given term.
The PR also includes some tests for this new function, as well as for `get_free_symbolic_constants`.
Since the computed set of operators is stored in an `unordered_set`, I also added a trivial `hash` function that relies on the string representation of the operators.