### PR TITLE
Adding an unsat core reduce function

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -121,6 +121,24 @@ public:
                                smt::TermVec *out_rem = NULL,
                                unsigned iter = 0,
                                unsigned rand_seed = 0);
+  
+
+  /** The additional method to reduce the assump (vector of assumptions). The method
+   *  assumes that the conjunction of the formula and assump is unsatisfiable.
+   *  This will iterate through the assump and requires at most size(assump) query
+   *  @param input formula
+   *  @param input vector of assumptions
+   *  @param output vector for the reduced assumptions
+   *  @param output vector for the removed assumptions
+   *  @param iter is the number of iterations done in the method. Default is 0,
+   *         and it means that the result in out_red will be minimal.
+   */
+  bool linear_reduce_assump_unsatcore(
+                               const smt::Term &formula,
+                               const smt::TermVec &assump,
+                               smt::TermVec &out_red,
+                               smt::TermVec *out_rem = NULL,
+                               unsigned iter = 0);
 
   /** This clears the term translation cache. Note, term translator is used to
    *  translate the terms of the external solver to the

--- a/include/utils.h
+++ b/include/utils.h
@@ -126,12 +126,16 @@ public:
   /** The additional method to reduce the assump (vector of assumptions). The method
    *  assumes that the conjunction of the formula and assump is unsatisfiable.
    *  This will iterate through the assump and requires at most size(assump) query
+   *  Note: this function assumes that there are no duplicate assumptions from the
+   *  second input vector.
    *  @param input formula
    *  @param input vector of assumptions
    *  @param output vector for the reduced assumptions
    *  @param output vector for the removed assumptions
    *  @param iter is the number of iterations done in the method. Default is 0,
    *         and it means that the result in out_red will be minimal.
+   *  returns false if the formula conjoined with the assump is satisfiable,
+   *          otherwise returns true
    */
   bool linear_reduce_assump_unsatcore(
                                const smt::Term &formula,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -317,7 +317,7 @@ bool UnsatCoreReducer::linear_reduce_assump_unsatcore(
         }
         // std::cout << "unsat, bool_assump size : " << bool_assump.size() << std::endl;
       }
-      assert(bool_assump.size() <= bool_assump_query);
+      assert(bool_assump.size() <= bool_assump_query.size());
       // we don't need to change assump_pos, because the size of
       // bool_assump is reduced by at least one, so in the next round
       // it is another element sitting at this location

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -172,7 +172,7 @@ bool UnsatCoreReducer::reduce_assump_unsatcore(const Term &formula,
   TermVec bool_assump, tmp_assump;
   UnorderedTermMap to_ext_assump;
   TermVec cand_res;
-  for (auto a : assump) {
+  for (const auto & a : assump) {
     Term t = to_reducer_.transfer_term(a);
     cand_res.push_back(t);
     to_ext_assump[t] = a;
@@ -193,7 +193,7 @@ bool UnsatCoreReducer::reduce_assump_unsatcore(const Term &formula,
             std::default_random_engine(rand_seed));
   }
 
-  for (auto &a : cand_res) {
+  for (const auto & a : cand_res) {
     Term l = label(a);
     reducer_->assert_formula(reducer_->make_term(Implies, l, a));
     bool_assump.push_back(l);
@@ -215,7 +215,7 @@ bool UnsatCoreReducer::reduce_assump_unsatcore(const Term &formula,
 
     UnorderedTermSet core_set;
     reducer_->get_unsat_core(core_set);
-    for (auto a : cand_res) {
+    for (const auto & a : cand_res) {
       Term l = label(a);
       if (core_set.find(l) != core_set.end()) {
         tmp_assump.push_back(a);
@@ -256,7 +256,7 @@ bool UnsatCoreReducer::linear_reduce_assump_unsatcore(
   TermVec bool_assump, tmp_assump;
   UnorderedTermMap to_ext_assump;
   TermVec cand_res;
-  for (auto a : assump) {
+  for (const auto & a : assump) {
     Term t = to_reducer_.transfer_term(a);
     cand_res.push_back(t);
     to_ext_assump[t] = a;
@@ -272,7 +272,7 @@ bool UnsatCoreReducer::linear_reduce_assump_unsatcore(
     return true;
   }
 
-  for (auto &a : cand_res) {
+  for (const auto & a : cand_res) {
     Term l = label(a);
     reducer_->assert_formula(reducer_->make_term(Implies, l, a));
     bool_assump.push_back(l);
@@ -310,7 +310,8 @@ bool UnsatCoreReducer::linear_reduce_assump_unsatcore(
         auto bool_assump_pos = bool_assump.begin();
         while(bool_assump_pos != bool_assump.end()) {
           // if not in the unsat core, remove it
-          if ( core_set.find(*bool_assump_pos) == core_set.end() )
+          if ( (bool_assump_pos - bool_assump.begin() == assump_pos) ||
+              core_set.find(*bool_assump_pos) == core_set.end() )
             bool_assump_pos = bool_assump.erase(bool_assump_pos);
           else
             ++ bool_assump_pos;  

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -287,7 +287,7 @@ bool UnsatCoreReducer::linear_reduce_assump_unsatcore(
   }
   assert(r.is_unsat());
   TermVec bool_assump_query;
-  UnorderedTermSet core_set;
+  UnorderedTermSet core_set(bool_assump.begin(), bool_assump.end());
 
   while (cur_iter <= iter && assump_pos < bool_assump.size()) {
     cur_iter = iter > 0 ? cur_iter+1 : cur_iter;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -205,8 +205,10 @@ bool UnsatCoreReducer::reduce_assump_unsatcore(const Term &formula,
     cur_iter = iter > 0 ? cur_iter+1 : cur_iter;
     r = reducer_->check_sat_assuming(bool_assump);
 
-    if (first_iter && r.is_sat())
+    if (first_iter && r.is_sat()) {
+      reducer_->pop();
       return false;
+    }
 
     assert(r.is_unsat());
 

--- a/tests/test-unsat-core-reducer.cpp
+++ b/tests/test-unsat-core-reducer.cpp
@@ -60,6 +60,23 @@ TEST_P(UnsatCoreReducerTests, UnsatCoreReducer)
   EXPECT_TRUE(rem[0] != red[0]);
 }
 
+TEST_P(UnsatCoreReducerTests, UnsatCoreReducerLinear)
+{
+  UnsatCoreReducer uscr(r);
+
+  Term a = s->make_symbol("a", boolsort);
+  Term b = s->make_symbol("b", boolsort);
+  Term formula = s->make_term(And, a, b);
+  TermVec assump({ s->make_term(Not, a), s->make_term(Not, b) });
+  TermVec red, rem;
+
+  uscr.linear_reduce_assump_unsatcore(formula, assump, red, &rem);
+  EXPECT_TRUE(red.size() == 1);
+  EXPECT_TRUE(rem.size() == 1);
+  EXPECT_TRUE(rem[0] != red[0]);
+}
+
+
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverUnsatCoreReducerTests,
     UnsatCoreReducerTests,

--- a/tests/test-unsat-core-reducer.cpp
+++ b/tests/test-unsat-core-reducer.cpp
@@ -71,9 +71,9 @@ TEST_P(UnsatCoreReducerTests, UnsatCoreReducerLinear)
   TermVec red, rem;
 
   uscr.linear_reduce_assump_unsatcore(formula, assump, red, &rem);
-  EXPECT_TRUE(red.size() == 1);
-  EXPECT_TRUE(rem.size() == 1);
-  EXPECT_TRUE(rem[0] != red[0]);
+  EXPECT_EQ(red.size() , 1);
+  EXPECT_EQ(rem.size() , 1);
+  EXPECT_NE(rem[0] , red[0]);
 }
 
 


### PR DESCRIPTION
This is to iterate through the unsat assumptions. This is used in SyGuS PDR and it guarantees to be minimal (but not minimum)
