### PR TITLE
Don't require boolean constants in check-sat-assuming

### DIFF
--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -319,28 +319,7 @@ Result BoolectorSolver::check_sat_assuming(const TermVec & assumptions)
   for (auto a : assumptions)
   {
     bt = std::static_pointer_cast<BoolectorTerm>(a);
-
-    bool is_literal = true;
-
-    BoolectorSort s = boolector_get_sort(bt->btor, bt->node);
-    // booleans are bit-vectors in boolector
-    is_literal &= boolector_is_bitvec_sort(bt->btor, s);
-    is_literal &= boolector_get_width(bt->btor, bt->node) == 1;
-
-    bool const_or_negated = a->is_symbolic_const();
-    if (!const_or_negated && bt->negated)
-    {
-      Term c = *(a->begin());
-      const_or_negated = c->is_symbolic_const();
-    }
-    is_literal &= const_or_negated;
-
-    if (!is_literal)
-    {
-      throw IncorrectUsageException(
-          "Assumptions to check_sat_assuming must be boolean literals");
-    }
-
+    assert(boolector_get_width(bt->btor, bt->node) == 1);
     boolector_assume(btor, bt->node);
   }
 

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -276,24 +276,6 @@ Result CVC4Solver::check_sat_assuming(const TermVec & assumptions)
 {
   try
   {
-    // expecting (possibly negated) boolean literals
-    for (auto a : assumptions)
-    {
-      if (!a->is_symbolic_const() || a->get_sort()->get_sort_kind() != BOOL)
-      {
-        if (a->get_op() == Not && (*a->begin())->is_symbolic_const())
-        {
-          continue;
-        }
-        else
-        {
-          throw IncorrectUsageException(
-              "Expecting boolean indicator literals but got: "
-              + a->to_string());
-        }
-      }
-    }
-
     std::vector<::CVC4::api::Term> cvc4assumps;
     cvc4assumps.reserve(assumptions.size());
 

--- a/tests/unit/unit-solving-interface.cpp
+++ b/tests/unit/unit-solving-interface.cpp
@@ -56,8 +56,19 @@ TEST_P(UnitSolveTests, CheckSatAssuming)
   s->assert_formula(s->make_term(Implies, b1, xeq0));
   s->assert_formula(s->make_term(Implies, nb2, nxeq0));
 
-  ASSERT_THROW(s->check_sat_assuming(TermVec{ xeq0 }), IncorrectUsageException);
-  Result r = s->check_sat_assuming(TermVec{ b1, nb2 });
+  Result r;
+  try
+  {
+    r = s->check_sat_assuming(TermVec{ xeq0, nb2 });
+  }
+  catch (IncorrectUsageException & e)
+  {
+    // mathsat is the only solver (so far)
+    // to have the restriction that assumptions must be
+    // (negated) boolean constants
+    EXPECT_EQ(s->get_solver_enum(), MSAT);
+    r = s->check_sat_assuming(TermVec{ b1, nb2 });
+  }
   ASSERT_TRUE(r.is_unsat());
 }
 

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -321,34 +321,6 @@ Result Yices2Solver::check_sat()
 
 Result Yices2Solver::check_sat_assuming(const TermVec & assumptions)
 {
-  // expecting (possibly negated) boolean literals
-  for (auto a : assumptions)
-  {
-    if (a->get_sort()->get_sort_kind() != BOOL)
-    {
-      throw IncorrectUsageException(
-          "Cannot assume a term with sort other than BOOL.");
-    }
-    else if (!a->is_symbolic_const())
-    {
-      shared_ptr<Yices2Term> yt = static_pointer_cast<Yices2Term>(a);
-      term_constructor_t tc = yices_term_constructor(yt->term);
-      if (tc == YICES_NOT_TERM && yices_term_num_children(yt->term) == 1
-          && yices_term_constructor(yices_term_child(yt->term, 0))
-                 == YICES_UNINTERPRETED_TERM
-          && yices_term_num_children(yices_term_child(yt->term, 0)) == 0)
-      {
-        // this is a negated boolean literal
-        continue;
-      }
-      else
-      {
-        throw IncorrectUsageException(
-            "Expecting boolean indicator literals but got: " + a->to_string());
-      }
-    }
-  }
-
   vector<term_t> y_assumps;
   y_assumps.reserve(assumptions.size());
 


### PR DESCRIPTION
This PR just makes it so that there's no artificial restriction on the assumptions to `check_sat_assuming`. MathSAT is the only solver that requires they be (negated) boolean constants, so that's the only solver that will throw an exception.

This PR makes other solvers more consistent. E.g. boolector will do top-level propagation, so if you assume:
`lbl <-> formula` 
at the top-level then `lbl` would not be considered a constant anymore, and before this change it would throw an exception when using `lbl` in `check_sat_assuming`. It makes more sense to allow `boolector` to have arbitrary boolean assumptions.

From the SMT-LIB level, the argument that this should be allowed in the API is that you can call `check_sat_assuming` with a `define-fun`. I.e. it's a symbol, but not necessarily a boolean constant. Therefore in the API it makes sense to be able to assume any formula. In the future, we could consider hiding the mathsat restriction at the smt-switch level.