### PR TITLE
disabling the generic solver on macos

### DIFF
--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -31,8 +31,7 @@ class GenericSolver : public AbsSmtSolver
   GenericSolver(std::string path,
                 std::vector<std::string> cmd_line_args,
                 uint write_buf_size = 256,
-                uint read_buf_size = 256,
-                SolverEnum se = SolverEnum::GENERIC_SOLVER);
+                uint read_buf_size = 256);
   ~GenericSolver();
   std::string to_smtlib_def(Term term) const;
   Sort make_sort(const std::string name, uint64_t arity) const override;

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -1,4 +1,3 @@
-#ifndef __APPLE__
 /*********************                                                        */
 /*! \file generic_solver.cpp
 ** \verbatim
@@ -18,6 +17,10 @@
 /* Uses code to interact with a process from:
 ** https://stackoverflow.com/a/6172578/1364765
 */
+
+
+// generic solvers are not supported on macos
+#ifndef __APPLE__
 
 #include "assert.h"
 
@@ -298,4 +301,5 @@ void GenericSolver::reset_assertions()
   }
 
 }  // namespace smt
-#endif
+
+#endif // __APPLE__

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -1,3 +1,4 @@
+#ifndef __APPLE__
 /*********************                                                        */
 /*! \file generic_solver.cpp
 ** \verbatim
@@ -29,6 +30,7 @@
 
 #include<unistd.h>
 #include<sys/wait.h>
+#include<sys/prctl.h>
 #include<signal.h>
 #include<stdlib.h>
 #include<string.h>
@@ -41,8 +43,8 @@ using namespace std;
 
 namespace smt {
 
-GenericSolver::GenericSolver(string path, vector<string> cmd_line_args, uint write_buf_size, uint read_buf_size, SolverEnum se)
-  : AbsSmtSolver(se), path(path), cmd_line_args(cmd_line_args), write_buf_size(write_buf_size), read_buf_size(read_buf_size),
+GenericSolver::GenericSolver(string path, vector<string> cmd_line_args, uint write_buf_size, uint read_buf_size)
+  : AbsSmtSolver(SolverEnum::GENERIC_SOLVER), path(path), cmd_line_args(cmd_line_args), write_buf_size(write_buf_size), read_buf_size(read_buf_size),
   name_sort_map(new unordered_map<string, Sort>()),
   sort_name_map(new unordered_map<Sort, string>()),
   name_term_map(new unordered_map<string, Term>()),
@@ -296,3 +298,4 @@ void GenericSolver::reset_assertions()
   }
 
 }  // namespace smt
+#endif

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -1,3 +1,4 @@
+#ifndef __APPLE__
 /*********************                                                        */
 /*! \file test-generic-solver.cpp
 ** \verbatim
@@ -46,3 +47,4 @@ int main() {
   GenericSolver s(STRFY(CVC4_HOME), std::vector<string>{"--lang=smt2", "--incremental", "--dag-thresh=0"}, 5, 5);
 #endif
 }
+#endif

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -1,4 +1,3 @@
-#ifndef __APPLE__
 /*********************                                                        */
 /*! \file test-generic-solver.cpp
 ** \verbatim
@@ -14,6 +13,10 @@
 **
 **
 **/
+
+// generic solvers are not supported on macos
+#ifndef __APPLE__
+
 #include <array>
 #include <cstdio>
 #include <fstream>
@@ -47,4 +50,5 @@ int main() {
   GenericSolver s(STRFY(CVC4_HOME), std::vector<string>{"--lang=smt2", "--incremental", "--dag-thresh=0"}, 5, 5);
 #endif
 }
-#endif
+
+#endif // __APPLE__


### PR DESCRIPTION
In case smt-switch is exited unexpectedly, we notify the generic solver sub-process.
We do so using a `prctl` system call, that is only available no unix, but not on mac os.
There are mac os alternatives, but we leave the task of using them for future PRs, after the entire generic solver is merged and is working on linux.

This PR disables the generic solver on macos using macros.
In addition, we remove the `SolverEnum` argument from the constructor of the generic solver, as it is known to be `GENERIC_SOLVER`.


Details about prctl and its macos alternatives:
https://stackoverflow.com/questions/284325/how-to-make-child-process-die-after-parent-exits