### PR TITLE
Communicating with Generic Solvers

### DIFF
--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -121,6 +121,12 @@ class GenericSolver : public AbsSmtSolver
 
   // verify that we got `success`
   void verify_success(std::string result) const;
+
+  // cmoputes  whether the current output from the solver
+  // is done being read
+  bool is_done(int just_read, std::string result) const;
+
+
   /***********
    * members *
    ***********/
@@ -156,8 +162,6 @@ class GenericSolver : public AbsSmtSolver
   // used to hash terms via their internal string representation
   std::hash<std::string> str_hash;
 
-  // flag that states whether current command is done being executed
-  bool is_done(int just_read, std::string result) const;
 };
 
 }  // namespace smt

--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -103,16 +103,34 @@ class GenericSolver : public AbsSmtSolver
   /******************
    * helper methods *
    *******************/
+
+  // open a connection to the binary via a pipe
   void start_solver();
+  // close the connection to the binary
   void close_solver();
 
+  // internal function to read solver's response
+  std::string read_internal() const;
+
+  // internal function to write to the solver's process
+  void write_internal(std::string str) const;
+
+  // run a command with the binary
+  std::string run_command(std::string cmd,
+                          bool verify_success_flag = true) const;
+
+  // verify that we got `success`
+  void verify_success(std::string result) const;
   /***********
    * members *
    ***********/
+
   // path to the solver binary
   std::string path;
+
   // command line arguments for the binary
   std::vector<std::string> cmd_line_args;
+
   // variables used for running processes
   int inpipefd[2];
   int outpipefd[2];
@@ -120,19 +138,26 @@ class GenericSolver : public AbsSmtSolver
   int status;
   char * write_buf;
   char * read_buf;
+
   // buffer sizes
   uint write_buf_size;
   uint read_buf_size;
+
   // maps between sort name and actual sort and vice verse
   std::unique_ptr<std::unordered_map<std::string, Sort>> name_sort_map;
   std::unique_ptr<std::unordered_map<Sort, std::string>> sort_name_map;
+
   // internal counter for naming terms
   uint * term_counter;
+
   // maps between sort name and actual sort and vice verse
   std::unique_ptr<std::unordered_map<std::string, Term>> name_term_map;
   std::unique_ptr<std::unordered_map<Term, std::string>> term_name_map;
   // used to hash terms via their internal string representation
   std::hash<std::string> str_hash;
+
+  // flag that states whether current command is done being executed
+  bool is_done(int just_read, std::string result) const;
 };
 
 }  // namespace smt

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -48,7 +48,7 @@ namespace smt {
 
 // helper functions
 //
-bool new_line(char c) { return (c == '\n' || c == '\r' || c == 0); }
+bool is_new_line(char c) { return (c == '\n' || c == '\r' || c == 0); }
 
 // from: https://stackoverflow.com/a/36000453/1364765
 std::string & trim(std::string & str)
@@ -197,7 +197,7 @@ bool GenericSolver::is_done(int just_read, std::string result) const
         count--;
       }
     }
-    done = (count == 0) && new_line(result[result.size() - 1]);
+    done = (count == 0) && is_new_line(result[result.size() - 1]);
   }
   else
   {
@@ -206,7 +206,7 @@ bool GenericSolver::is_done(int just_read, std::string result) const
     assert(just_read <= read_buf_size);
     for (int i = 0; i < just_read; i++)
     {
-      if (new_line(read_buf[i]))
+      if (is_new_line(read_buf[i]))
       {
         done = true;
       }

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -43,11 +43,58 @@
 using namespace smt;
 using namespace std;
 
-int main() {
+void test_binary(string path, vector<string> args)
+{
+  std::cout << "testing binary: " << path << std::endl;
+  std::cout << "constructing solver" << std::endl;
+  SmtSolver gs = std::make_shared<GenericSolver>(path, args, 5, 5);
+  std::cout << "setting an option" << std::endl;
+  gs->set_opt("produce-models", "true");
+}
 
+int main() {
+  // testing a non-existing binary
+  string path;
+  vector<string> args;
+  try
+  {
+    path = "/non/existing/path";
+    test_binary(path, args);
+  }
+  catch (IncorrectUsageException e)
+  {
+    std::cout << "caught an exception" << std::endl;
+  }
+
+// testing with cvc4 binary
 #if BUILD_CVC4
-  cout << "testing with CVC4 binary" << endl;
-  GenericSolver s(STRFY(CVC4_HOME), std::vector<string>{"--lang=smt2", "--incremental", "--dag-thresh=0"}, 5, 5);
+  path = (STRFY(CVC4_HOME));
+  path += "/build/bin/cvc4";
+  args = { "--lang=smt2", "--incremental", "--dag-thresh=0" };
+  test_binary(path, args);
+#endif
+
+// testing with msat binary
+#if BUILD_MSAT
+  path = (STRFY(MSAT_HOME));
+  path += "/bin/mathsat";
+  args = { "" };
+  test_binary(path, args);
+#endif
+
+  // testing with cvc4 binary
+#if BUILD_YICES2
+  path = (STRFY(YICES2_HOME));
+  path += "/build/bin/yices_smt2";
+  args = { "--incremental" };
+  test_binary(path, args);
+#endif
+
+  // testing with cvc4 binary
+#if BUILD_BTOR
+  path = (STRFY(BTOR_HOME));
+  path += "/build/bin/btor";
+  args = { "--incremental" } test_binary(path, args);
 #endif
 }
 

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -93,8 +93,9 @@ int main() {
   // testing with cvc4 binary
 #if BUILD_BTOR
   path = (STRFY(BTOR_HOME));
-  path += "/build/bin/btor";
-  args = { "--incremental" } test_binary(path, args);
+  path += "/build/bin/boolector";
+  args = { "--incremental" }; 
+  test_binary(path, args);
 #endif
 }
 


### PR DESCRIPTION
This PR introduces the code that communicates with a solver binary, runs commands, and read their results.
Only the infrastructure for that is included, as well as support for `set option` command.
More commands will be added in subsequent PRs.

The generic solver test now tries to communicate with all available solver binaries.