### PR TITLE
Generic solver implementations: creating sorts

### DIFF
--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -302,6 +302,10 @@ Sort GenericSolver::make_sort(const Sort & sort_con, const SortVec & sorts) cons
   // creating the new sort
   Sort sort = make_uninterpreted_generic_sort(sort_con, sorts);
 
+  // note that there is no need to communicate anything
+  // to the solver yet. When the sort will be used,
+  // we will print the right name to the solver.
+
   // assigning a name to the new sort
   string name = sort->get_uninterpreted_name();
 
@@ -346,6 +350,10 @@ Sort GenericSolver::make_sort(const SortKind sk) const
   Sort sort = make_generic_sort(sk);
   // compute the name of the sort
   string name = sort->to_string();
+
+  // note that nothing needs to be communicated to the solver,
+  // as in this case the sort is built in.
+
   // store in local maps if needed, and return the sort
   if (name_sort_map->find(name) == name_sort_map->end())
   {
@@ -365,6 +373,10 @@ Sort GenericSolver::make_sort(const SortKind sk, uint64_t size) const
   Sort sort = make_generic_sort(sk, size);
   // compute the name
   string name = sort->to_string();
+
+  // note that nothing needs to be communicated to the solver,
+  // as in this case the sort is built in.
+
   // store in maps if needed and return the sort
   if (name_sort_map->find(name) == name_sort_map->end())
   {
@@ -404,6 +416,11 @@ Sort GenericSolver::make_sort(SortKind sk, const SortVec & sorts) const
   Sort sort = make_generic_sort(sk, sorts);
   // compute the name
   string name = sort->to_string();
+
+  // note that nothing needs to be communicated to the solver,
+  // as in this case the sort is built in, or can used
+  // by combining sorts that were already defined.
+
   // store in maps if needed and return the sort
   if (name_sort_map->find(name) == name_sort_map->end())
   {

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -47,7 +47,6 @@ using namespace std;
 namespace smt {
 
 // helper functions
-//
 bool is_new_line(char c) { return (c == '\n' || c == '\r' || c == 0); }
 
 // from: https://stackoverflow.com/a/36000453/1364765
@@ -287,33 +286,85 @@ void GenericSolver::close_solver() {
 }
  
 Sort GenericSolver::make_sort(const Sort & sort_con, const SortVec & sorts) const {
-  assert(false);
+  assert(sort_name_map->find(sort_con) != sort_name_map->end());
+  assert(sort_con->get_arity() == sorts.size());
+  for (Sort sort : sorts)
+  {
+    assert(sort_name_map->find(sort) != sort_name_map->end());
+  }
+  Sort sort = make_uninterpreted_generic_sort(sort_con, sorts);
+  string name = sort->get_uninterpreted_name();
+  if (name_sort_map->find(name) != name_sort_map->end())
+  {
+    return (*name_sort_map)[name];
+  }
+  else
+  {
+    (*name_sort_map)[name] = sort;
+    (*sort_name_map)[sort] = name;
+    return sort;
+  }
 }
 
 Sort GenericSolver::make_sort(const std::string name, uint64_t arity) const {
-  assert(false);
+  if (name_sort_map->find(name) == name_sort_map->end())
+  {
+    Sort sort = make_uninterpreted_generic_sort(name, arity);
+    (*name_sort_map)[name] = sort;
+    (*sort_name_map)[sort] = name;
+    run_command("(" + DECLARE_SORT_STR + " " + name + " "
+                + std::to_string(arity) + ")");
+    return sort;
+  }
+  else
+  {
+    throw IncorrectUsageException(string("sort name: ") + name
+                                  + string(" already taken"));
+  }
 }
 
 Sort GenericSolver::make_sort(const SortKind sk) const
 {
-  assert(false);
+  Sort sort = make_generic_sort(sk);
+  string name = sort->to_string();
+  if (name_sort_map->find(name) == name_sort_map->end())
+  {
+    (*name_sort_map)[name] = sort;
+    (*sort_name_map)[sort] = name;
+    return sort;
+  }
+  else
+  {
+    return name_sort_map->at(name);
+  }
 }
 
 Sort GenericSolver::make_sort(const SortKind sk, uint64_t size) const
 {
-  assert(false);
+  Sort sort = make_generic_sort(sk, size);
+  string name = sort->to_string();
+  if (name_sort_map->find(name) == name_sort_map->end())
+  {
+    (*name_sort_map)[name] = sort;
+    (*sort_name_map)[sort] = name;
+    return sort;
+  }
+  else
+  {
+    return name_sort_map->at(name);
+  }
 }
 
 Sort GenericSolver::make_sort(const SortKind sk, const Sort & sort1) const
 {
-  assert(false);
+  return make_sort(sk, SortVec({ sort1 }));
 }
 
 Sort GenericSolver::make_sort(const SortKind sk,
                               const Sort & sort1,
                               const Sort & sort2) const
 {
-  assert(false);
+  return make_sort(sk, SortVec({ sort1, sort2 }));
 }
 
 Sort GenericSolver::make_sort(const SortKind sk,
@@ -321,12 +372,23 @@ Sort GenericSolver::make_sort(const SortKind sk,
                               const Sort & sort2,
                               const Sort & sort3) const
 {
-  assert(false);
+  return make_sort(sk, SortVec({ sort1, sort2, sort3 }));
 }
 
 Sort GenericSolver::make_sort(SortKind sk, const SortVec & sorts) const
 {
-  assert(false);
+  Sort sort = make_generic_sort(sk, sorts);
+  string name = sort->to_string();
+  if (name_sort_map->find(name) == name_sort_map->end())
+  {
+    (*name_sort_map)[name] = sort;
+    (*sort_name_map)[sort] = name;
+    return sort;
+  }
+  else
+  {
+    return name_sort_map->at(name);
+  }
 }
 
 
@@ -460,7 +522,7 @@ void GenericSolver::set_opt(const std::string option, const std::string value)
 
 void GenericSolver::set_logic(const std::string logic)
 {
-  assert(false);
+  run_command("(" + SET_LOGIC_STR + " " + logic + ")");
 }
 
 void GenericSolver::assert_formula(const Term & t)

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -286,14 +286,26 @@ void GenericSolver::close_solver() {
 }
  
 Sort GenericSolver::make_sort(const Sort & sort_con, const SortVec & sorts) const {
+  // When constructing a sort, the sort constructor
+  // must have been already processed
   assert(sort_name_map->find(sort_con) != sort_name_map->end());
+  // The arity of the sort constructor must match
+  // the number of arguments
   assert(sort_con->get_arity() == sorts.size());
+
+  // All the input sorts must have been processed
   for (Sort sort : sorts)
   {
     assert(sort_name_map->find(sort) != sort_name_map->end());
   }
+
+  // creating the new sort
   Sort sort = make_uninterpreted_generic_sort(sort_con, sorts);
+
+  // assigning a name to the new sort
   string name = sort->get_uninterpreted_name();
+
+  // store in the map if missing, and return the new sort
   if (name_sort_map->find(name) != name_sort_map->end())
   {
     return (*name_sort_map)[name];
@@ -307,11 +319,16 @@ Sort GenericSolver::make_sort(const Sort & sort_con, const SortVec & sorts) cons
 }
 
 Sort GenericSolver::make_sort(const std::string name, uint64_t arity) const {
+  // when creating a new uninterpreted sort, the name
+  // must be new.
   if (name_sort_map->find(name) == name_sort_map->end())
   {
+    // create the sort
     Sort sort = make_uninterpreted_generic_sort(name, arity);
+    // store the sort and the name in the maps
     (*name_sort_map)[name] = sort;
     (*sort_name_map)[sort] = name;
+    // declare the sort to the binary of the solver
     run_command("(" + DECLARE_SORT_STR + " " + name + " "
                 + std::to_string(arity) + ")");
     return sort;
@@ -325,8 +342,11 @@ Sort GenericSolver::make_sort(const std::string name, uint64_t arity) const {
 
 Sort GenericSolver::make_sort(const SortKind sk) const
 {
+  // create the sort
   Sort sort = make_generic_sort(sk);
+  // compute the name of the sort
   string name = sort->to_string();
+  // store in local maps if needed, and return the sort
   if (name_sort_map->find(name) == name_sort_map->end())
   {
     (*name_sort_map)[name] = sort;
@@ -341,8 +361,11 @@ Sort GenericSolver::make_sort(const SortKind sk) const
 
 Sort GenericSolver::make_sort(const SortKind sk, uint64_t size) const
 {
+  // create the sort
   Sort sort = make_generic_sort(sk, size);
+  // compute the name
   string name = sort->to_string();
+  // store in maps if needed and return the sort
   if (name_sort_map->find(name) == name_sort_map->end())
   {
     (*name_sort_map)[name] = sort;
@@ -377,8 +400,11 @@ Sort GenericSolver::make_sort(const SortKind sk,
 
 Sort GenericSolver::make_sort(SortKind sk, const SortVec & sorts) const
 {
+  // create the sort
   Sort sort = make_generic_sort(sk, sorts);
+  // compute the name
   string name = sort->to_string();
+  // store in maps if needed and return the sort
   if (name_sort_map->find(name) == name_sort_map->end())
   {
     (*name_sort_map)[name] = sort;
@@ -390,7 +416,6 @@ Sort GenericSolver::make_sort(SortKind sk, const SortVec & sorts) const
     return name_sort_map->at(name);
   }
 }
-
 
 Sort GenericSolver::make_sort(const DatatypeDecl & d) const
 {

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -43,6 +43,214 @@
 using namespace smt;
 using namespace std;
 
+void init_solver(SmtSolver gs)
+{
+  gs->set_opt("produce-models", "true");
+  gs->set_opt("produce-unsat-assumptions", "true");
+  gs->set_logic("ALL");
+}
+
+void new_btor(SmtSolver & gs)
+{
+  gs.reset();
+  string path = (STRFY(BTOR_HOME));
+  path += "/build/bin/boolector";
+  vector<string> args = { "--incremental" };
+  gs = std::make_shared<GenericSolver>(path, args, 5, 5);
+  init_solver(gs);
+}
+
+void new_msat(SmtSolver & gs)
+{
+  gs.reset();
+  string path = (STRFY(MSAT_HOME));
+  path += "/bin/mathsat";
+  vector<string> args = { "" };
+  gs = std::make_shared<GenericSolver>(path, args, 5, 5);
+  init_solver(gs);
+}
+
+void new_yices2(SmtSolver & gs)
+{
+  gs.reset();
+  string path = (STRFY(YICES2_HOME));
+  path += "/build/bin/yices_smt2";
+  vector<string> args = { "--incremental" };
+  gs = std::make_shared<GenericSolver>(path, args, 5, 5);
+  init_solver(gs);
+}
+
+void new_cvc4(SmtSolver & gs)
+{
+  gs.reset();
+  string path = (STRFY(CVC4_HOME));
+  path += "/build/bin/cvc4";
+  vector<string> args = { "--lang=smt2", "--incremental", "--dag-thresh=0" };
+  gs = std::make_shared<GenericSolver>(path, args, 5, 5);
+  init_solver(gs);
+}
+
+void test_bad_cmd(SmtSolver gs)
+{
+  cout << "trying a bad command:" << endl;
+  try
+  {
+    gs->set_opt("iiiaaaaiiiiaaaa", "aaa");
+  }
+  catch (IncorrectUsageException e)
+  {
+    cout << "caught the exception" << endl;
+  }
+}
+
+void test_uf_1(SmtSolver gs)
+{
+  Sort s = gs->make_sort("S", 0);
+  cout << "created a sort! " << s << endl;
+  cout << "trying to create it again" << endl;
+  try
+  {
+    Sort s1 = gs->make_sort("S", 1);
+  }
+  catch (IncorrectUsageException e)
+  {
+    cout << "caught the exception" << endl;
+  }
+}
+
+void test_int_1(SmtSolver gs)
+{
+  Sort int_sort = gs->make_sort(INT);
+  cout << "created sort of sort kind " << to_string(INT)
+       << ". The sort is: " << int_sort << endl;
+
+  Sort int_sort2 = gs->make_sort(INT);
+  assert(int_sort == int_sort2);
+
+  cout << "trying to create a sort in a wrong way" << endl;
+  try
+  {
+    Sort err_sort = gs->make_sort(ARRAY);
+  }
+  catch (IncorrectUsageException e)
+  {
+    cout << "caught the exception" << endl;
+  }
+}
+
+void test_bv_1(SmtSolver gs)
+{
+  Sort bv_sort = gs->make_sort(BV, 4);
+  cout << "created bit-vector sort: " << bv_sort << endl;
+
+  cout << "checking for equalities" << endl;
+  Sort bv_sort1 = gs->make_sort(BV, 4);
+  assert(bv_sort == bv_sort1);
+  Sort bv_sort2 = gs->make_sort(BV, 5);
+  assert(bv_sort != bv_sort2);
+
+  cout << "trying to create a sort in a wrong way" << endl;
+  try
+  {
+    Sort err_sort = gs->make_sort(INT, bv_sort);
+  }
+  catch (IncorrectUsageException e)
+  {
+    cout << "caught the exception" << endl;
+  }
+}
+
+void test_bv_2(SmtSolver gs)
+{
+  cout << "trying to create a sort in a wrong way" << endl;
+  try
+  {
+    Sort err_sort = gs->make_sort(INT, 4);
+  }
+  catch (IncorrectUsageException e)
+  {
+    cout << "caught the exception" << endl;
+  }
+}
+
+void test_cvc4()
+{
+  cout << "testing cvc4" << endl;
+  SmtSolver gs;
+
+  new_cvc4(gs);
+  test_bad_cmd(gs);
+
+  new_cvc4(gs);
+  test_uf_1(gs);
+
+  new_cvc4(gs);
+  test_int_1(gs);
+
+  new_cvc4(gs);
+  test_bv_1(gs);
+
+  new_cvc4(gs);
+  test_bv_2(gs);
+}
+
+void test_yices2()
+{
+  cout << "testing yices2" << endl;
+  SmtSolver gs;
+
+  new_yices2(gs);
+  test_bad_cmd(gs);
+
+  new_yices2(gs);
+  test_uf_1(gs);
+
+  new_yices2(gs);
+  test_int_1(gs);
+
+  new_yices2(gs);
+  test_bv_1(gs);
+
+  new_yices2(gs);
+  test_bv_2(gs);
+}
+
+void test_msat()
+{
+  cout << "testing msat" << endl;
+  SmtSolver gs;
+
+  new_msat(gs);
+  test_bad_cmd(gs);
+
+  new_msat(gs);
+  test_uf_1(gs);
+
+  new_msat(gs);
+  test_int_1(gs);
+
+  new_msat(gs);
+  test_bv_1(gs);
+
+  new_msat(gs);
+  test_bv_2(gs);
+}
+
+void test_btor()
+{
+  cout << "testing btor" << endl;
+  SmtSolver gs;
+
+  new_btor(gs);
+  test_bad_cmd(gs);
+
+  new_btor(gs);
+  test_bv_1(gs);
+
+  new_btor(gs);
+  test_bv_2(gs);
+}
+
 void test_binary(string path, vector<string> args)
 {
   std::cout << "testing binary: " << path << std::endl;
@@ -68,34 +276,22 @@ int main() {
 
 // testing with cvc4 binary
 #if BUILD_CVC4
-  path = (STRFY(CVC4_HOME));
-  path += "/build/bin/cvc4";
-  args = { "--lang=smt2", "--incremental", "--dag-thresh=0" };
-  test_binary(path, args);
+  test_cvc4();
 #endif
 
 // testing with msat binary
 #if BUILD_MSAT
-  path = (STRFY(MSAT_HOME));
-  path += "/bin/mathsat";
-  args = { "" };
-  test_binary(path, args);
+  test_msat();
 #endif
 
   // testing with cvc4 binary
 #if BUILD_YICES2
-  path = (STRFY(YICES2_HOME));
-  path += "/build/bin/yices_smt2";
-  args = { "--incremental" };
-  test_binary(path, args);
+  test_yices2();
 #endif
 
   // testing with cvc4 binary
 #if BUILD_BTOR
-  path = (STRFY(BTOR_HOME));
-  path += "/build/bin/boolector";
-  args = { "--incremental" }; 
-  test_binary(path, args);
+  test_btor();
 #endif
 }
 


### PR DESCRIPTION
This PR provides the implementations of the various `make_sort` functions.
It also extends the test file, where each of the available binaries is tested only on sorts that it supports.