### PR TITLE
Generic Solver: Infrastructure for terms + Boolean constants

### DIFF
--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -33,6 +33,7 @@ class GenericSolver : public AbsSmtSolver
                 uint write_buf_size = 256,
                 uint read_buf_size = 256);
   ~GenericSolver();
+  // returns a string representation of a term in smtlib
   std::string to_smtlib_def(Term term) const;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(const SortKind sk) const override;
@@ -103,7 +104,10 @@ class GenericSolver : public AbsSmtSolver
   /******************
    * helper methods *
    *******************/
-  // store a term in the internal cache
+  // store a term in the internal maps and return the stored term
+  // The returned term might be a different object than the input term.
+  // For example, if a term with the same content has already been stored,
+  // the old term is returned.
   Term store_term(Term term) const;
   // parse result (sat, unsat, unknown) from solver's output
   Result str_to_result(std::string result) const;

--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -103,6 +103,8 @@ class GenericSolver : public AbsSmtSolver
   /******************
    * helper methods *
    *******************/
+  // store a term in the internal cache
+  Term store_term(Term term) const;
   // parse result (sat, unsat, unknown) from solver's output
   Result str_to_result(std::string result) const;
 
@@ -110,6 +112,13 @@ class GenericSolver : public AbsSmtSolver
   void start_solver();
   // close the connection to the binary
   void close_solver();
+  // internally defining and storing a function symbol
+  void define_fun(std::string str,
+                  smt::SortVec args_sorts,
+                  smt::Sort res_sort,
+                  smt::Term defining_term) const;
+  // get the name of a term
+  std::string get_name(Term t) const;
 
   // internal function to read solver's response
   std::string read_internal() const;

--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -33,8 +33,10 @@ class GenericSolver : public AbsSmtSolver
                 uint write_buf_size = 256,
                 uint read_buf_size = 256);
   ~GenericSolver();
+
   // returns a string representation of a term in smtlib
   std::string to_smtlib_def(Term term) const;
+
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(const SortKind sk) const override;
   Sort make_sort(const SortKind sk, uint64_t size) const override;
@@ -104,11 +106,14 @@ class GenericSolver : public AbsSmtSolver
   /******************
    * helper methods *
    *******************/
-  // store a term in the internal maps and return the stored term
-  // The returned term might be a different object than the input term.
-  // For example, if a term with the same content has already been stored,
-  // the old term is returned.
+
+  /** store a term in the internal maps and return the stored term
+   * The returned term might be a different object than the input term.
+   * For example, if a term with the same content has already been stored,
+   * the old term is returned.
+   */
   Term store_term(Term term) const;
+
   // parse result (sat, unsat, unknown) from solver's output
   Result str_to_result(std::string result) const;
 
@@ -116,11 +121,13 @@ class GenericSolver : public AbsSmtSolver
   void start_solver();
   // close the connection to the binary
   void close_solver();
+
   // internally defining and storing a function symbol
   void define_fun(std::string str,
                   smt::SortVec args_sorts,
                   smt::Sort res_sort,
                   smt::Term defining_term) const;
+
   // get the name of a term
   std::string get_name(Term t) const;
 

--- a/include/generic_term.h
+++ b/include/generic_term.h
@@ -51,7 +51,7 @@ class GenericTerm : public AbsTerm
   bool is_value() const override;
   uint64_t to_int() const override;
   std::string print_value_as(SortKind sk) override;
-  // used to hash terms via their string representation
+  // is this a ground term
   bool is_ground() const;
   bool is_symbol() const override;
   bool is_param() const override;
@@ -65,6 +65,7 @@ class GenericTerm : public AbsTerm
 
   /** check whether this is a ground term
    * (does not have free variables)
+   * Should only be called from the constructor.
    */
   bool compute_ground();
 

--- a/include/generic_term.h
+++ b/include/generic_term.h
@@ -51,6 +51,8 @@ class GenericTerm : public AbsTerm
   bool is_value() const override;
   uint64_t to_int() const override;
   std::string print_value_as(SortKind sk) override;
+  // used to hash terms via their string representation
+  bool is_ground() const;
   bool is_symbol() const override;
   bool is_param() const override;
   bool is_symbolic_const() const override;
@@ -60,6 +62,14 @@ class GenericTerm : public AbsTerm
 
  protected:
   std::string compute_string() const;
+
+  /** check whether this is a ground term
+   * (does not have free variables)
+   */
+  bool compute_ground();
+
+  // true iff this is a ground term
+  bool ground;
 
   /**
    * A hash function for strings,

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -566,7 +566,7 @@ Term GenericSolver::store_term(Term term) const
     // we send a command:
     // `(define-fun t1 () Int 0)`
     // If in the future we see a term `0+0`, it will
-    // be send to the solver as `(+ t1 t1)`.
+    // be sent to the solver as `(+ t1 t1)`.
     //
     // However, terms with bound variables cannot be given to
     // a define-fun command. For them, we store

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -290,31 +290,47 @@ void GenericSolver::close_solver() {
   kill(pid, SIGKILL);
   waitpid(pid, &status, 0);
 }
- 
-void GenericSolver::define_fun(std::string name, SortVec args_sorts, Sort res_sort, Term defining_term) const{
-  //for now, we practically only support define-const
+
+void GenericSolver::define_fun(std::string name,
+                               SortVec args_sorts,
+                               Sort res_sort,
+                               Term defining_term) const
+{
+  // for now, we practically only support define-const
   assert(args_sorts.size() == 0);
   assert(sort_name_map->find(res_sort) != sort_name_map->end());
-  run_command("(" + DEFINE_FUN_STR + " " + name + " () " + (*sort_name_map)[res_sort] + " " + to_smtlib_def(defining_term) + ")");
+  run_command("(" + DEFINE_FUN_STR + " " + name + " () "
+              + (*sort_name_map)[res_sort] + " " + to_smtlib_def(defining_term)
+              + ")");
 }
 
-std::string GenericSolver::to_smtlib_def(Term term) const {
+std::string GenericSolver::to_smtlib_def(Term term) const
+{
   shared_ptr<GenericTerm> gt = static_pointer_cast<GenericTerm>(term);
-  if (gt->get_op().is_null()) {
+  if (gt->get_op().is_null())
+  {
     return gt->repr;
-  } else {
+  }
+  else
+  {
     string result = "(";
-    result += ((term->get_op().prim_op == Apply) ? "" : term->get_op().to_string());
-    if (term->get_op().prim_op == Forall || term->get_op().prim_op == Exists) {
-      result += " ((" + (*term_name_map)[gt->get_children()[0]] + " " + (*sort_name_map)[gt->get_children()[0]->get_sort()] + ")) " + (*term_name_map)[gt->get_children()[1]];
-    } 
-    else {
-      for (auto c : gt->get_children()) {
+    result +=
+        ((term->get_op().prim_op == Apply) ? "" : term->get_op().to_string());
+    if (term->get_op().prim_op == Forall || term->get_op().prim_op == Exists)
+    {
+      result += " ((" + (*term_name_map)[gt->get_children()[0]] + " "
+                + (*sort_name_map)[gt->get_children()[0]->get_sort()] + ")) "
+                + (*term_name_map)[gt->get_children()[1]];
+    }
+    else
+    {
+      for (auto c : gt->get_children())
+      {
         result += " " + (*term_name_map)[c];
       }
     }
-  result += ")";
-  return result;
+    result += ")";
+    return result;
   }
 }
 
@@ -512,20 +528,25 @@ Term GenericSolver::get_selector(const Sort & s, std::string con, std::string na
   assert(false);  
 }
 
-std::string GenericSolver::get_name(Term term) const {
+std::string GenericSolver::get_name(Term term) const
+{
   *term_counter = (*term_counter) + 1;
   return "t_" + std::to_string((*term_counter));
-  
 }
 
-Term GenericSolver::store_term(Term term) const {
+Term GenericSolver::store_term(Term term) const
+{
   shared_ptr<GenericTerm> gterm = static_pointer_cast<GenericTerm>(term);
-  if (term_name_map->find(gterm) == term_name_map->end()) {
+  if (term_name_map->find(gterm) == term_name_map->end())
+  {
     string name;
-    if (gterm->is_ground()) {
+    if (gterm->is_ground())
+    {
       name = get_name(gterm);
       define_fun(name, SortVec{}, gterm->get_sort(), gterm);
-    } else {
+    }
+    else
+    {
       name = to_smtlib_def(gterm);
     }
     (*name_term_map)[name] = gterm;
@@ -538,8 +559,8 @@ Term GenericSolver::store_term(Term term) const {
 Term GenericSolver::make_term(bool b) const
 {
   Sort boolsort = make_sort(BOOL);
-  Term term =
-      std::make_shared<GenericTerm>(boolsort, Op(), TermVec{}, b ? "true" : "false");
+  Term term = std::make_shared<GenericTerm>(
+      boolsort, Op(), TermVec{}, b ? "true" : "false");
   return store_term(term);
 }
 

--- a/src/generic_term.cpp
+++ b/src/generic_term.cpp
@@ -45,13 +45,19 @@ GenericTerm::GenericTerm(Sort s, Op o, TermVec c, string r, bool is_sym)
 
 bool GenericTerm::compute_ground()
 {
+  // parameters are not ground terms
   if (is_param())
   {
     return false;
   }
+  // if one of the children is not ground, then the term
+  // is not ground.
   for (Term child : get_children())
   {
     shared_ptr<GenericTerm> gc = static_pointer_cast<GenericTerm>(child);
+    // This is not a recursive call -- is_ground is
+    // just a getter. Their `ground` member
+    // was initialized upon their construction.
     if (!gc->is_ground())
     {
       return false;

--- a/src/generic_term.cpp
+++ b/src/generic_term.cpp
@@ -25,19 +25,14 @@ namespace smt {
 
 /* GenericTerm */
 
-GenericTerm::GenericTerm(Sort s, Op o, TermVec c, string r) 
-    : sort(s),
-      op(o),
-      children(c),
-      repr(r),
-      is_sym(false),
-      is_par(false)
+GenericTerm::GenericTerm(Sort s, Op o, TermVec c, string r)
+    : sort(s), op(o), children(c), repr(r), is_sym(false), is_par(false)
 {
   ground = compute_ground();
 }
 
 GenericTerm::GenericTerm(Sort s, Op o, TermVec c, string r, bool is_sym)
-: sort(s),
+    : sort(s),
       op(o),
       children(c),
       repr(r),
@@ -48,13 +43,17 @@ GenericTerm::GenericTerm(Sort s, Op o, TermVec c, string r, bool is_sym)
   ground = compute_ground();
 }
 
-bool GenericTerm::compute_ground() {
-  if (is_param()) {
+bool GenericTerm::compute_ground()
+{
+  if (is_param())
+  {
     return false;
   }
-  for (Term child : get_children()) {
+  for (Term child : get_children())
+  {
     shared_ptr<GenericTerm> gc = static_pointer_cast<GenericTerm>(child);
-    if (!gc->is_ground()) {
+    if (!gc->is_ground())
+    {
       return false;
     }
   }
@@ -63,11 +62,9 @@ bool GenericTerm::compute_ground() {
 
 GenericTerm::~GenericTerm() {}
 
-
 Op GenericTerm::get_op() const { return op; }
 
-
-TermVec GenericTerm::get_children() {return children;}
+TermVec GenericTerm::get_children() { return children; }
 
 Sort GenericTerm::get_sort() const { return sort; }
 
@@ -142,11 +139,12 @@ size_t GenericTerm::hash() const { return str_hash(compute_string()); }
 
 // check if op is null because a non-value
 // may have been simplified to a value by the underlying solver
-bool GenericTerm::is_value() const {return op == Op() && !is_param() && !is_symbolic_const();  }
-
-bool GenericTerm::is_ground() const{
-  return ground;
+bool GenericTerm::is_value() const
+{
+  return op == Op() && !is_param() && !is_symbolic_const();
 }
+
+bool GenericTerm::is_ground() const { return ground; }
 
 uint64_t GenericTerm::to_int() const { assert(false); }
 

--- a/src/generic_term.cpp
+++ b/src/generic_term.cpp
@@ -25,26 +25,49 @@ namespace smt {
 
 /* GenericTerm */
 
-GenericTerm::GenericTerm(Sort s, Op o, TermVec c, string r)
-    : sort(s), op(o), children(c), repr(r), is_sym(false), is_par(false)
-{
-}
-
-GenericTerm::GenericTerm(Sort s, Op o, TermVec c, string r, bool is_sym)
+GenericTerm::GenericTerm(Sort s, Op o, TermVec c, string r) 
     : sort(s),
       op(o),
       children(c),
       repr(r),
-      is_sym(is_sym),
-      is_par(!is_sym)
+      is_sym(false),
+      is_par(false)
 {
+  ground = compute_ground();
+}
+
+GenericTerm::GenericTerm(Sort s, Op o, TermVec c, string r, bool is_sym)
+: sort(s),
+      op(o),
+      children(c),
+      repr(r),
+      is_sym(is_sym),
+      is_par(!is_sym),
+      ground(true)
+{
+  ground = compute_ground();
+}
+
+bool GenericTerm::compute_ground() {
+  if (is_param()) {
+    return false;
+  }
+  for (Term child : get_children()) {
+    shared_ptr<GenericTerm> gc = static_pointer_cast<GenericTerm>(child);
+    if (!gc->is_ground()) {
+      return false;
+    }
+  }
+  return true;
 }
 
 GenericTerm::~GenericTerm() {}
 
+
 Op GenericTerm::get_op() const { return op; }
 
-TermVec GenericTerm::get_children() { return children; }
+
+TermVec GenericTerm::get_children() {return children;}
 
 Sort GenericTerm::get_sort() const { return sort; }
 
@@ -119,9 +142,10 @@ size_t GenericTerm::hash() const { return str_hash(compute_string()); }
 
 // check if op is null because a non-value
 // may have been simplified to a value by the underlying solver
-bool GenericTerm::is_value() const
-{
-  return op == Op() && !is_param() && !is_symbolic_const();
+bool GenericTerm::is_value() const {return op == Op() && !is_param() && !is_symbolic_const();  }
+
+bool GenericTerm::is_ground() const{
+  return ground;
 }
 
 uint64_t GenericTerm::to_int() const { assert(false); }

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -20,25 +20,24 @@
 #include <array>
 #include <cstdio>
 #include <fstream>
-#include <iostream>
-#include <memory>
-#include <sstream>
+#include <cstdio>
 #include <stdexcept>
 #include <string>
+#include <array>
+#include <iostream>
+#include <memory>
 #include <vector>
-
+#include <sstream>
 #include "assert.h"
 
 // note: this file depends on the CMake build infrastructure
 // specifically defined macros
 // it cannot be compiled outside of the build
+#include "test-utils.h"
+
 #include "cvc4_factory.h"
 #include "generic_solver.h"
-#include "generic_sort.h"
-#include "generic_term.h"
-#include "gtest/gtest.h"
 #include "smt.h"
-#include "test-utils.h"
 
 using namespace smt;
 using namespace std;
@@ -87,6 +86,55 @@ void test_bool_1(SmtSolver gs)
   gs->assert_formula(term_1);
   r = gs->check_sat();
   assert(r.is_sat());
+  gs->pop(1);
+}
+
+void test_bool_2(SmtSolver gs) {
+  cout << "trying to create a constant boolean term" << endl;
+  Term true_term_1 = gs->make_term(true);
+  Term false_term_1 = gs->make_term(false);
+  cout << "got term: " << true_term_1 << endl;
+  cout << "got term: " << false_term_1 << endl;
+
+  cout << "trying to create a constant boolean term again" << endl;
+  Term true_term_2 = gs->make_term(true);
+  Term false_term_2 = gs->make_term(false);
+  cout << "got term: " << true_term_2 << endl;
+  cout << "got term: " << false_term_2 << endl;
+  assert(true_term_1.get() == true_term_2.get());
+  assert(false_term_1.get() == false_term_2.get());
+
+  Term true_term = true_term_1;
+  Term false_term = false_term_1;
+
+  Result r; 
+
+  cout << "checking satisfiability with no assertions" << endl;
+  gs->push(1);
+  r = gs->check_sat();
+  assert(r.is_sat());
+  gs->pop(1);
+  
+  cout << "checking satisfiability with assertion that is true" << endl;
+  gs->push(1);
+  gs->assert_formula(true_term);
+  r = gs->check_sat();
+  assert(r.is_sat()); 
+  gs->pop(1);
+
+  cout << "checking satisfiability with assertion that is false" << endl;
+  gs->push(1);
+  gs->assert_formula(false_term);
+  r = gs->check_sat();
+  assert(r.is_unsat());
+  gs->pop(1);
+
+  cout << "checking satisfiability with assertions that are false and true" << endl;
+  gs->push(1);
+  gs->assert_formula(false_term);
+  gs->assert_formula(true_term);
+  r = gs->check_sat();
+  assert(r.is_unsat()); 
   gs->pop(1);
 }
 
@@ -204,6 +252,9 @@ void test_msat()
   test_bool_1(gs);
 
   new_msat(gs);
+  test_bool_2(gs);
+  
+  new_msat(gs);
   test_uf_1(gs);
 
   new_msat(gs);
@@ -227,6 +278,9 @@ void test_yices2()
   new_yices2(gs);
   test_bool_1(gs);
 
+  new_yices2(gs);
+  test_bool_2(gs);
+  
   new_yices2(gs);
   test_uf_1(gs);
 
@@ -252,6 +306,9 @@ void test_cvc4()
   test_bool_1(gs);
 
   new_cvc4(gs);
+  test_bool_2(gs);
+
+  new_cvc4(gs);
   test_uf_1(gs);
 
   new_cvc4(gs);
@@ -274,6 +331,9 @@ void test_btor()
 
   new_btor(gs);
   test_bool_1(gs);
+
+  new_btor(gs);
+  test_bool_2(gs);
 
   new_btor(gs);
   test_bv_1(gs);

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -20,24 +20,22 @@
 #include <array>
 #include <cstdio>
 #include <fstream>
-#include <cstdio>
-#include <stdexcept>
-#include <string>
-#include <array>
 #include <iostream>
 #include <memory>
-#include <vector>
 #include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
 #include "assert.h"
 
 // note: this file depends on the CMake build infrastructure
 // specifically defined macros
 // it cannot be compiled outside of the build
-#include "test-utils.h"
-
 #include "cvc4_factory.h"
 #include "generic_solver.h"
 #include "smt.h"
+#include "test-utils.h"
 
 using namespace smt;
 using namespace std;
@@ -89,7 +87,8 @@ void test_bool_1(SmtSolver gs)
   gs->pop(1);
 }
 
-void test_bool_2(SmtSolver gs) {
+void test_bool_2(SmtSolver gs)
+{
   cout << "trying to create a constant boolean term" << endl;
   Term true_term_1 = gs->make_term(true);
   Term false_term_1 = gs->make_term(false);
@@ -107,19 +106,19 @@ void test_bool_2(SmtSolver gs) {
   Term true_term = true_term_1;
   Term false_term = false_term_1;
 
-  Result r; 
+  Result r;
 
   cout << "checking satisfiability with no assertions" << endl;
   gs->push(1);
   r = gs->check_sat();
   assert(r.is_sat());
   gs->pop(1);
-  
+
   cout << "checking satisfiability with assertion that is true" << endl;
   gs->push(1);
   gs->assert_formula(true_term);
   r = gs->check_sat();
-  assert(r.is_sat()); 
+  assert(r.is_sat());
   gs->pop(1);
 
   cout << "checking satisfiability with assertion that is false" << endl;
@@ -129,12 +128,13 @@ void test_bool_2(SmtSolver gs) {
   assert(r.is_unsat());
   gs->pop(1);
 
-  cout << "checking satisfiability with assertions that are false and true" << endl;
+  cout << "checking satisfiability with assertions that are false and true"
+       << endl;
   gs->push(1);
   gs->assert_formula(false_term);
   gs->assert_formula(true_term);
   r = gs->check_sat();
-  assert(r.is_unsat()); 
+  assert(r.is_unsat());
   gs->pop(1);
 }
 
@@ -253,7 +253,7 @@ void test_msat()
 
   new_msat(gs);
   test_bool_2(gs);
-  
+
   new_msat(gs);
   test_uf_1(gs);
 
@@ -280,7 +280,7 @@ void test_yices2()
 
   new_yices2(gs);
   test_bool_2(gs);
-  
+
   new_yices2(gs);
   test_uf_1(gs);
 


### PR DESCRIPTION
This PR adds the infrastructure to create terms via the generic solver.

Most of the functions that are added are `protected`, as they deal with the internal state of the generic solver and how it communicates with the binary.

The only new public function that is added allows to create Boolean constants.

The test file is extended with a test that involves Boolean constants.