### PR TITLE
Download CVC4 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,14 @@ script:
   # brew sometimes fails on something after the python installation -- but we don't want the build to fail
   - ./travis-scripts/travis-setup-osx-python.sh || true
   - sudo python3 -m pip install Cython==0.29 --install-option="--no-cython-compile"
-  - bash -c "./travis-scripts/setup-${SOLVER}.sh ${OPTS}"
+  # Temporarily download CVC4 instead of building it
+  # There's some issue on mac with get-antlr-3.4
+  - |
+    if [ $SOLVER == "cvc4" ]; then
+        ./travis-scripts/download-cvc4.sh;
+    else
+        ./travis-scripts/setup-${SOLVER}.sh ${OPTS}
+    fi
   - bash -c "./contrib/setup-skbuild.sh"
   - bash -c "./configure.sh --debug --${SOLVER} --python"
   - bash -c "cd build && make -j && make test"

--- a/travis-scripts/download-cvc4.sh
+++ b/travis-scripts/download-cvc4.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DEPS=$DIR/../deps
+
+mkdir -p $DEPS
+
+
+usage () {
+    cat <<EOF
+Usage: $0 [<option> ...]
+
+Downloads a precompiled CVC4 SMT Solver,
+
+-h, --help              display this message and exit
+EOF
+    exit 0
+}
+
+while [ $# -gt 0 ]
+do
+    case $1 in
+        -h|--help) usage;;
+        *) die "unexpected argument: $1";;
+    esac
+    shift
+done
+
+if [ ! -d "$DEPS/CVC4" ]; then
+    cd $DEPS
+    if [[ "$OSTYPE" == linux* ]]; then
+        curl -o CVC4.tar.bz2 -L http://web.stanford.edu/~makaim/files/CVC4-linux.tar.bz2
+    elif [[ "$OSTYPE" == darwin* ]]; then
+        curl -o CVC4.tar.bz2 -L http://web.stanford.edu/~makaim/files/CVC4-mac.tar.bz2
+    elif [[ "$OSTYPE" == msys* ]]; then
+        echo "Pre-compiled libraries for Windows not yet available"
+    elif [[ "$OSTYPE" == cygwin* ]]; then
+        curl -o CVC4.tar.bz2 -L http://web.stanford.edu/~makaim/files/CVC4-linux.tar.bz2
+    else
+        echo "Unrecognized OSTYPE=$OSTYPE"
+        exit 1
+    fi
+
+    tar -xf CVC4.tar.bz2
+    rm CVC4.tar.bz2
+
+else
+    echo "$DEPS/CVC4 already exists. If you want to re-download, please remove it manually."
+    exit 1
+fi
+
+if [ -f $DEPS/CVC4/build/src/libcvc4.a ] ; then \
+    echo "It appears CVC4 was setup successfully into $DEPS/CVC4."
+    echo "You may now install it with make ./configure.sh --msat && cd build && make"
+else
+    echo "Downloading CVC4 failed."
+    exit 1
+fi


### PR DESCRIPTION
There's a recurring issue with Travis Mac build where the CVC4 script `get-antlr-3.4` fails to download ANTLR. This has been happening periodically the last few days. This PR instead downloads pre-compiled versions of CVC4 for the Travis builds. It also has the nice side effect of speeding up the builds.

The downside is that we must maintain the pre-compiled binaries separately. We could also consider looking into downloading pre-compiled binaries from another source at some point.