### PR TITLE
Generic Solver: get-value, get-unsat-core, check-sat-assuming

### DIFF
--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -122,6 +122,7 @@ class GenericSolver : public AbsSmtSolver
 
   // parse result (sat, unsat, unknown) from solver's output
   Result str_to_result(std::string result) const;
+  
   // parse actual value from a get-value response
   std::string strip_value_from_result(std::string result) const;
 

--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -122,7 +122,7 @@ class GenericSolver : public AbsSmtSolver
 
   // parse result (sat, unsat, unknown) from solver's output
   Result str_to_result(std::string result) const;
-  
+
   // parse actual value from a get-value response
   std::string strip_value_from_result(std::string result) const;
 

--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -106,6 +106,9 @@ class GenericSolver : public AbsSmtSolver
   /******************
    * helper methods *
    *******************/
+  // parse solver's response from get-sat-assumptions
+  UnorderedTermSet get_assumptions_from_string(std::string result) const;
+
   // create an smt-lib constant array value.
   // used for make_term
   std::string cons_arr_string(const Term & val, const Sort & sort) const;
@@ -119,6 +122,8 @@ class GenericSolver : public AbsSmtSolver
 
   // parse result (sat, unsat, unknown) from solver's output
   Result str_to_result(std::string result) const;
+  // parse actual value from a get-value response
+  std::string strip_value_from_result(std::string result) const;
 
   /** helper function for bv constant
    * abs_decimal is the string represnentation of the absolute value of the

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -1010,6 +1010,7 @@ Result GenericSolver::check_sat_assuming(const TermVec & assumptions)
   string names;
   for (Term t : assumptions)
   {
+    // assumptions can only be Boolean literals
     if (!t->is_symbolic_const() || t->get_sort()->get_sort_kind() != BOOL)
     {
       if (t->get_op() != Not || !((*t->begin())->is_symbolic_const()))
@@ -1018,9 +1019,13 @@ Result GenericSolver::check_sat_assuming(const TermVec & assumptions)
             "Expecting boolean indicator literals but got: " + t->to_string());
       }
     }
+
+    // add the name of the literal to the list of assumptions
     assert(term_name_map->find(t) != term_name_map->end());
     names += " " + (*term_name_map)[t];
   }
+
+  // send command to the solver and parse it
   string result =
       run_command("(" + CHECK_SAT_ASSUMING_STR + " (" + names + "))", false);
   Result r = str_to_result(result);

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -762,11 +762,12 @@ Term GenericSolver::make_term(const Op op, const TermVec & terms) const
 
 Term GenericSolver::get_value(const Term & t) const
 {
-  // we do not support getting array values, function values, and uninterpreted values.
+  // we do not support getting array values, function values, and uninterpreted
+  // values.
   Sort sort = t->get_sort();
   assert(sort->get_sort_kind() != ARRAY && sort->get_sort_kind() != FUNCTION
          && sort->get_sort_kind() != UNINTERPRETED);
-  
+
   // get the name of the term (the way the term is defined in the solver)
   assert(term_name_map->find(t) != term_name_map->end());
   string name = (*term_name_map)[t];
@@ -777,8 +778,8 @@ Term GenericSolver::get_value(const Term & t) const
 
   // translate the string representation of the result into a term
   Term resulting_term;
-  // for bit-vectors, we distinguish between the solver's way of representing them.
-  // it can be either binary, hex, or decimal.
+  // for bit-vectors, we distinguish between the solver's way of representing
+  // them. it can be either binary, hex, or decimal.
   if (sort->get_sort_kind() == BV)
   {
     if (value.substr(0, 2) == "#b")
@@ -815,14 +816,14 @@ string GenericSolver::strip_value_from_result(string result) const
 {
   // trim spaces
   result = trim(result);
-  
+
   // value string ends at first ")" or end of string.
   int end_of_value = result.size() - 1;
   while (result.at(end_of_value) == ')' || result.at(end_of_value) == ' ')
   {
     end_of_value--;
   }
-  
+
   // value string begins at the first non-space after '('
   int start_of_value = end_of_value;
   while (result.at(start_of_value) != '(')
@@ -864,10 +865,10 @@ void GenericSolver::get_unsat_core(UnorderedTermSet & out)
 
 UnorderedTermSet GenericSolver::get_assumptions_from_string(string result) const
 {
-  // the result from the solver is a 
+  // the result from the solver is a
   // space-separated list of Boolean literals.
   UnorderedTermSet literals;
-  
+
   // trim the result from spaces
   result = trim(result);
 
@@ -887,7 +888,7 @@ UnorderedTermSet GenericSolver::get_assumptions_from_string(string result) const
     // beginning and end of literal
     int begin;
     int end;
-    
+
     // negative literal
     if (strip.substr(index, 5) == "(not ")
     {

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -1011,13 +1011,10 @@ Result GenericSolver::check_sat_assuming(const TermVec & assumptions)
   for (Term t : assumptions)
   {
     // assumptions can only be Boolean literals
-    if (!t->is_symbolic_const() || t->get_sort()->get_sort_kind() != BOOL)
+    if (t->get_sort()->get_sort_kind() != BOOL)
     {
-      if (t->get_op() != Not || !((*t->begin())->is_symbolic_const()))
-      {
         throw IncorrectUsageException(
             "Expecting boolean indicator literals but got: " + t->to_string());
-      }
     }
 
     // add the name of the literal to the list of assumptions

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -232,6 +232,7 @@ void test_int_2(SmtSolver gs)
   assert(r.is_sat());
   gs->pop(1);
 }
+
 void test_bad_term_1(SmtSolver gs)
 {
   cout << "trying to create a badly-sorted term and getting and exception"
@@ -377,9 +378,6 @@ void test_bool(SmtSolver gs)
   Term true_term = true_term_1;
   Term false_term = false_term_1;
 
-  // TODO reset doesn't work... I don't know why.
-  // gs->reset();
-
   Result r;
 
   cout << "checking satisfiability with no assertions" << endl;
@@ -387,7 +385,6 @@ void test_bool(SmtSolver gs)
   r = gs->check_sat();
   assert(r.is_sat());
   gs->pop(1);
-
   cout << "checking satisfiability with assertion that is true" << endl;
   gs->push(1);
   gs->assert_formula(true_term);
@@ -412,6 +409,41 @@ void test_bool(SmtSolver gs)
   gs->pop(1);
 }
 
+void test_abv_2(SmtSolver gs)
+{
+  std::cout << "test_abv_2" << std::endl;
+  gs->push(1);
+  Sort bv_sort1 = gs->make_sort(BV, 4);
+  Sort bv_sort2 = gs->make_sort(BV, 5);
+  Sort bv_to_bv = gs->make_sort(ARRAY, bv_sort1, bv_sort2);
+  Sort bv_x_bv_to_array = gs->make_sort(FUNCTION, bv_sort1, bv_sort2, bv_to_bv);
+
+  Term complex1 = gs->make_symbol("complex1", bv_x_bv_to_array);
+  Sort bv_sort = gs->make_sort(BV, 4);
+  Term bv_zero = gs->make_term(0, bv_sort);
+  Term bv_one = gs->make_term(1, bv_sort);
+
+  Term arr1 = gs->make_term(
+      Apply,
+      TermVec{ complex1,
+               bv_zero,
+               gs->make_term(
+                   Concat, bv_one, gs->make_term("0", gs->make_sort(BV, 1))) });
+  Term sel1 = gs->make_term(Select, arr1, bv_one);
+  Term dis1 =
+      gs->make_term(Distinct, sel1, gs->make_term("1", gs->make_sort(BV, 5)));
+
+  gs->push(1);
+  Term bv1 = gs->make_symbol("bv", bv_sort);
+  Term for1 = gs->make_term(Equal, bv1, bv_zero);
+  gs->assert_formula(for1);
+  gs->assert_formula(dis1);
+  Result result = gs->check_sat();
+  assert(result.is_sat());
+  Term val = gs->get_value(bv1);
+  gs->pop(1);
+}
+
 void test_quantifiers(SmtSolver gs)
 {
   gs->push(1);
@@ -425,7 +457,6 @@ void test_quantifiers(SmtSolver gs)
   gs->assert_formula(forall1);
   Result result = gs->check_sat();
   assert(result.is_sat());
-
   Term matrix2 = gs->make_term(Gt, par1, par2);
   Term forall2 = gs->make_term(Forall, par1, matrix2);
   Term exists2 = gs->make_term(Exists, par2, forall2);
@@ -434,6 +465,91 @@ void test_quantifiers(SmtSolver gs)
   assert(result.is_unsat());
   gs->pop(1);
 }
+
+void test_constant_arrays(SmtSolver gs)
+{
+  // Testing constant arrays
+  gs->push(1);
+  Sort bvsort = gs->make_sort(BV, 4);
+  Sort arrsort = gs->make_sort(ARRAY, bvsort, bvsort);
+  Term zero = gs->make_term(0, bvsort);
+  Term constarr0 = gs->make_term(zero, arrsort);
+  Term arr = gs->make_symbol("arr", arrsort);
+  Term arreq = gs->make_term(Equal, arr, constarr0);
+  gs->assert_formula(arreq);
+  Result result = gs->check_sat();
+  assert(result.is_sat());
+  gs->pop(1);
+}
+
+void test_int_models(SmtSolver gs)
+{
+  // Testing models
+  gs->push(1);
+  Sort int_sort = gs->make_sort(INT);
+  Term int_zero = gs->make_term(0, int_sort);
+  Term i1 = gs->make_symbol("i", int_sort);
+  Term for1 = gs->make_term(Equal, i1, int_zero);
+  gs->assert_formula(for1);
+  Result result = gs->check_sat();
+  assert(result.is_sat());
+  Term val = gs->get_value(i1);
+  gs->pop(1);
+}
+
+void test_bv_models(SmtSolver gs)
+{
+  // Testing models
+  gs->push(1);
+  Sort bv_sort = gs->make_sort(BV, 4);
+  Term bv_zero = gs->make_term(0, bv_sort);
+  Term i1 = gs->make_symbol("i", bv_sort);
+  Term for1 = gs->make_term(Equal, i1, bv_zero);
+  gs->assert_formula(for1);
+  Result result = gs->check_sat();
+  assert(result.is_sat());
+  Term val = gs->get_value(i1);
+  gs->pop(1);
+}
+
+void test_check_sat_assuming(SmtSolver gs)
+{
+  // Testing check-sat-assuming
+  gs->push(1);
+  Sort bool_sort = gs->make_sort(BOOL);
+  Term b1 = gs->make_symbol("bool1", bool_sort);
+  Term not_b1 = gs->make_term(Not, b1);
+  Term b2 = gs->make_symbol("bool2", bool_sort);
+  Term b3 = gs->make_symbol("bool3", bool_sort);
+  gs->assert_formula(b1);
+  Result r;
+  r = gs->check_sat_assuming(TermVec{ not_b1, b2, b3 });
+  assert(r.is_unsat());
+  gs->pop(1);
+}
+
+void test_unsat_assumptions(SmtSolver gs)
+{
+  // Testing unsat-assumptions
+  gs->push(1);
+  Sort bool_sort = gs->make_sort(BOOL);
+  Term b1 = gs->make_symbol("bool11", bool_sort);
+  Term not_b1 = gs->make_term(Not, b1);
+  Term b2 = gs->make_symbol("bool22", bool_sort);
+  Term b3 = gs->make_symbol("bool33", bool_sort);
+  gs->assert_formula(b1);
+  Result r = gs->check_sat_assuming(TermVec{ not_b1, b2, b3 });
+  assert(r.is_unsat());
+  UnorderedTermSet core;
+  gs->get_unsat_core(core);
+  std::cout << "core: " << std::endl;
+  for (Term t : core)
+  {
+    std::cout << t << std::endl;
+  }
+  gs->pop(1);
+}
+
 void init_solver(SmtSolver gs)
 {
   gs->set_opt("produce-models", "true");
@@ -483,8 +599,14 @@ void new_cvc4(SmtSolver & gs)
 
 void test_msat()
 {
-  cout << "testing msat" << endl;
+  cout << "testing mathsat" << endl;
   SmtSolver gs;
+
+  new_msat(gs);
+  test_bad_term_1(gs);
+
+  new_msat(gs);
+  test_bad_term_2(gs);
 
   new_msat(gs);
   test_bad_cmd(gs);
@@ -499,25 +621,19 @@ void test_msat()
   test_bool_2(gs);
 
   new_msat(gs);
+  test_uf_2(gs);
+
+  new_msat(gs);
   test_int_1(gs);
+
+  new_msat(gs);
+  test_int_2(gs);
 
   new_msat(gs);
   test_bv_1(gs);
 
   new_msat(gs);
   test_bv_2(gs);
-
-  new_msat(gs);
-  test_uf_2(gs);
-
-  new_msat(gs);
-  test_int_2(gs);
-
-  new_msat(gs);
-  test_bad_term_1(gs);
-
-  new_msat(gs);
-  test_bad_term_2(gs);
 
   new_msat(gs);
   test_bv_3(gs);
@@ -529,16 +645,40 @@ void test_msat()
   test_abv_1(gs);
 
   new_msat(gs);
+  test_abv_2(gs);
+
+  new_msat(gs);
   test_bool(gs);
+
+  new_msat(gs);
+  test_constant_arrays(gs);
+
+  new_msat(gs);
+  test_int_models(gs);
+
+  new_msat(gs);
+  test_bv_models(gs);
+
+  new_msat(gs);
+  test_check_sat_assuming(gs);
+
+  new_msat(gs);
+  test_unsat_assumptions(gs);
 }
 
 void test_yices2()
 {
-  cout << "testing yices2" << endl;
+  cout << "testing yices" << endl;
   SmtSolver gs;
 
   new_yices2(gs);
   test_bad_cmd(gs);
+
+  new_yices2(gs);
+  test_bad_term_1(gs);
+
+  new_yices2(gs);
+  test_bad_term_2(gs);
 
   new_yices2(gs);
   test_uf_1(gs);
@@ -550,25 +690,19 @@ void test_yices2()
   test_bool_2(gs);
 
   new_yices2(gs);
+  test_uf_2(gs);
+
+  new_yices2(gs);
   test_int_1(gs);
+
+  new_yices2(gs);
+  test_int_2(gs);
 
   new_yices2(gs);
   test_bv_1(gs);
 
   new_yices2(gs);
   test_bv_2(gs);
-
-  new_yices2(gs);
-  test_uf_2(gs);
-
-  new_yices2(gs);
-  test_int_2(gs);
-
-  new_yices2(gs);
-  test_bad_term_1(gs);
-
-  new_yices2(gs);
-  test_bad_term_2(gs);
 
   new_yices2(gs);
   test_bv_3(gs);
@@ -580,7 +714,22 @@ void test_yices2()
   test_abv_1(gs);
 
   new_yices2(gs);
+  test_abv_2(gs);
+
+  new_yices2(gs);
   test_bool(gs);
+
+  new_yices2(gs);
+  test_int_models(gs);
+
+  new_yices2(gs);
+  test_bv_models(gs);
+
+  new_yices2(gs);
+  test_check_sat_assuming(gs);
+
+  new_yices2(gs);
+  test_unsat_assumptions(gs);
 }
 
 void test_cvc4()
@@ -589,10 +738,25 @@ void test_cvc4()
   SmtSolver gs;
 
   new_cvc4(gs);
-  test_bad_cmd(gs);
+  test_bad_term_1(gs);
 
   new_cvc4(gs);
+  test_bad_term_2(gs);
+
+  new_msat(gs);
   test_uf_1(gs);
+
+  new_cvc4(gs);
+  test_uf_2(gs);
+
+  new_cvc4(gs);
+  test_int_1(gs);
+
+  new_cvc4(gs);
+  test_int_2(gs);
+
+  new_cvc4(gs);
+  test_bad_cmd(gs);
 
   new_cvc4(gs);
   test_bool_1(gs);
@@ -601,25 +765,10 @@ void test_cvc4()
   test_bool_2(gs);
 
   new_cvc4(gs);
-  test_int_1(gs);
-
-  new_cvc4(gs);
   test_bv_1(gs);
 
   new_cvc4(gs);
   test_bv_2(gs);
-
-  new_cvc4(gs);
-  test_uf_2(gs);
-
-  new_cvc4(gs);
-  test_int_2(gs);
-
-  new_cvc4(gs);
-  test_bad_term_1(gs);
-
-  new_cvc4(gs);
-  test_bad_term_2(gs);
 
   new_cvc4(gs);
   test_bv_3(gs);
@@ -631,10 +780,28 @@ void test_cvc4()
   test_abv_1(gs);
 
   new_cvc4(gs);
+  test_abv_2(gs);
+
+  new_cvc4(gs);
   test_bool(gs);
 
   new_cvc4(gs);
   test_quantifiers(gs);
+
+  new_cvc4(gs);
+  test_constant_arrays(gs);
+
+  new_cvc4(gs);
+  test_int_models(gs);
+
+  new_cvc4(gs);
+  test_bv_models(gs);
+
+  new_cvc4(gs);
+  test_check_sat_assuming(gs);
+
+  new_cvc4(gs);
+  test_unsat_assumptions(gs);
 }
 
 void test_btor()
@@ -643,6 +810,12 @@ void test_btor()
   SmtSolver gs;
 
   new_btor(gs);
+  test_bad_term_1(gs);
+
+  new_btor(gs);
+  test_bad_term_2(gs);
+
+  new_btor(gs);
   test_bad_cmd(gs);
 
   new_btor(gs);
@@ -667,7 +840,16 @@ void test_btor()
   test_abv_1(gs);
 
   new_btor(gs);
+  test_bv_models(gs);
+
+  new_btor(gs);
   test_bool(gs);
+
+  new_btor(gs);
+  test_check_sat_assuming(gs);
+
+  new_btor(gs);
+  test_unsat_assumptions(gs);
 }
 
 void test_binary(string path, vector<string> args)

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -512,7 +512,7 @@ void test_bv_models(SmtSolver gs)
   gs->pop(1);
 }
 
-void test_check_sat_assuming(SmtSolver gs)
+void test_check_sat_assuming_1(SmtSolver gs)
 {
   // Testing check-sat-assuming
   gs->push(1);
@@ -525,6 +525,27 @@ void test_check_sat_assuming(SmtSolver gs)
   Result r;
   r = gs->check_sat_assuming(TermVec{ not_b1, b2, b3 });
   assert(r.is_unsat());
+  gs->pop(1);
+}
+
+void test_check_sat_assuming_2(SmtSolver gs)
+{
+  // Testing check-sat-assuming
+  gs->push(1);
+  Sort bv_sort = gs->make_sort(BV, 4);
+  Term bv1 = gs->make_symbol("bv1", bv_sort);
+  Term bv2 = gs->make_symbol("bv2", bv_sort);
+
+  Term b1 = gs->make_term(Equal, bv1, gs->make_term(BVNot, bv2));
+  Term not_b1 = gs->make_term(Not, b1);
+
+  Term b2 = gs->make_term(BVUgt, bv1, bv2);
+
+  Term b3 = gs->make_term(BVUgt, bv2, gs->make_term(3, bv_sort));
+  gs->assert_formula(b1);
+  Result r;
+  r = gs->check_sat_assuming(TermVec{ b2, b3 });
+  assert(r.is_sat());
   gs->pop(1);
 }
 
@@ -660,7 +681,10 @@ void test_msat()
   test_bv_models(gs);
 
   new_msat(gs);
-  test_check_sat_assuming(gs);
+  test_check_sat_assuming_1(gs);
+
+  new_msat(gs);
+  test_check_sat_assuming_2(gs);
 
   new_msat(gs);
   test_unsat_assumptions(gs);
@@ -726,7 +750,10 @@ void test_yices2()
   test_bv_models(gs);
 
   new_yices2(gs);
-  test_check_sat_assuming(gs);
+  test_check_sat_assuming_1(gs);
+
+  new_yices2(gs);
+  test_check_sat_assuming_2(gs);
 
   new_yices2(gs);
   test_unsat_assumptions(gs);
@@ -798,7 +825,10 @@ void test_cvc4()
   test_bv_models(gs);
 
   new_cvc4(gs);
-  test_check_sat_assuming(gs);
+  test_check_sat_assuming_1(gs);
+
+  new_cvc4(gs);
+  test_check_sat_assuming_2(gs);
 
   new_cvc4(gs);
   test_unsat_assumptions(gs);
@@ -846,7 +876,10 @@ void test_btor()
   test_bool(gs);
 
   new_btor(gs);
-  test_check_sat_assuming(gs);
+  test_check_sat_assuming_1(gs);
+
+  new_btor(gs);
+  test_check_sat_assuming_2(gs);
 
   new_btor(gs);
   test_unsat_assumptions(gs);

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -761,7 +761,6 @@ void test_yices2()
 
 void test_cvc4()
 {
-  cout << "testing cvc4" << endl;
   SmtSolver gs;
 
   new_cvc4(gs);
@@ -770,7 +769,7 @@ void test_cvc4()
   new_cvc4(gs);
   test_bad_term_2(gs);
 
-  new_msat(gs);
+  new_cvc4(gs);
   test_uf_1(gs);
 
   new_cvc4(gs);


### PR DESCRIPTION
This PR introduces implementations of `get-value`, `get-unsat-core` and `check-sat-assuming` in the generic solver.
It also removes support for non 0-ary uninterpreted sorts (the implementation was added by mistake previously).
Tests are added for the new functions.