### PR TITLE
Provide list and set versions of check_sat_assuming

### DIFF
--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -58,6 +58,7 @@ class BoolectorSolver : public AbsSmtSolver
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
   Result check_sat_assuming_list(const TermList & assumptions) override;
+  Result check_sat_assuming_set(const UnorderedTermSet & assumptions) override;
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   Term get_value(const Term & t) const override;

--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -57,6 +57,7 @@ class BoolectorSolver : public AbsSmtSolver
   void assert_formula(const Term & t) override;
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
+  Result check_sat_assuming_list(const TermList & assumptions) override;
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   Term get_value(const Term & t) const override;
@@ -132,6 +133,34 @@ class BoolectorSolver : public AbsSmtSolver
   ///< reset_assertions yet
   ///< set this flag with set_opt("base-context-1", "true")
   size_t context_level = 0;  ///< tracks the current solving context level
+
+  // helper functions
+  template <class I>
+  inline Result check_sat_assuming(I it, const I & end)
+  {
+    std::shared_ptr<BoolectorTerm> bt;
+    while (it != end)
+    {
+      bt = std::static_pointer_cast<BoolectorTerm>(*it);
+      assert(boolector_get_width(bt->btor, bt->node) == 1);
+      boolector_assume(btor, bt->node);
+      ++it;
+    }
+
+    int32_t res = boolector_sat(btor);
+    if (res == BOOLECTOR_SAT)
+    {
+      return Result(SAT);
+    }
+    else if (res == BOOLECTOR_UNSAT)
+    {
+      return Result(UNSAT);
+    }
+    else
+    {
+      return Result(UNKNOWN);
+    }
+  }
 };
 }  // namespace smt
 

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -321,6 +321,12 @@ Result BoolectorSolver::check_sat_assuming_list(const TermList & assumptions)
   return check_sat_assuming(assumptions.begin(), assumptions.end());
 }
 
+Result BoolectorSolver::check_sat_assuming_set(
+    const UnorderedTermSet & assumptions)
+{
+  return check_sat_assuming(assumptions.begin(), assumptions.end());
+}
+
 void BoolectorSolver::push(uint64_t num)
 {
   boolector_push(btor, num);

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -313,29 +313,12 @@ Result BoolectorSolver::check_sat()
 
 Result BoolectorSolver::check_sat_assuming(const TermVec & assumptions)
 {
-  // boolector supports assuming arbitrary one-bit expressions,
-  // not just boolean literals
-  std::shared_ptr<BoolectorTerm> bt;
-  for (auto a : assumptions)
-  {
-    bt = std::static_pointer_cast<BoolectorTerm>(a);
-    assert(boolector_get_width(bt->btor, bt->node) == 1);
-    boolector_assume(btor, bt->node);
-  }
+  return check_sat_assuming(assumptions.begin(), assumptions.end());
+}
 
-  int32_t res = boolector_sat(btor);
-  if (res == BOOLECTOR_SAT)
-  {
-    return Result(SAT);
-  }
-  else if (res == BOOLECTOR_UNSAT)
-  {
-    return Result(UNSAT);
-  }
-  else
-  {
-    return Result(UNKNOWN);
-  }
+Result BoolectorSolver::check_sat_assuming_list(const TermList & assumptions)
+{
+  return check_sat_assuming(assumptions.begin(), assumptions.end());
 }
 
 void BoolectorSolver::push(uint64_t num)

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -57,6 +57,7 @@ class CVC4Solver : public AbsSmtSolver
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
   Result check_sat_assuming_list(const TermList & assumptions) override;
+  Result check_sat_assuming_set(const UnorderedTermSet & assumptions) override;
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   Term get_value(const Term & t) const override;

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -56,6 +56,7 @@ class CVC4Solver : public AbsSmtSolver
   void assert_formula(const Term & t) override;
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
+  Result check_sat_assuming_list(const TermList & assumptions) override;
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   Term get_value(const Term & t) const override;
@@ -118,6 +119,29 @@ class CVC4Solver : public AbsSmtSolver
   ::CVC4::api::Solver solver;
   // keep track of created symbols
   std::unordered_map<std::string, Term> symbols;
+
+  // helper function
+  inline Result check_sat_assuming(
+      const std::vector<CVC4::api::Term> & cvc4assumps)
+  {
+    ::CVC4::api::Result r = solver.checkSatAssuming(cvc4assumps);
+    if (r.isUnsat())
+    {
+      return Result(UNSAT);
+    }
+    else if (r.isSat())
+    {
+      return Result(SAT);
+    }
+    else if (r.isSatUnknown())
+    {
+      return Result(UNKNOWN, r.getUnknownExplanation());
+    }
+    else
+    {
+      throw NotImplementedException("Unimplemented result type from CVC4");
+    }
+  }
 };
 
 //Interpolating Solver

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -284,23 +284,27 @@ Result CVC4Solver::check_sat_assuming(const TermVec & assumptions)
     {
       cvc4assumps.push_back(std::static_pointer_cast<CVC4Term>(a)->term);
     }
-    ::CVC4::api::Result r = solver.checkSatAssuming(cvc4assumps);
-    if (r.isUnsat())
+    return check_sat_assuming(cvc4assumps);
+  }
+  catch (::CVC4::api::CVC4ApiException & e)
+  {
+    throw InternalSolverException(e.what());
+  }
+}
+
+Result CVC4Solver::check_sat_assuming_list(const TermList & assumptions)
+{
+  try
+  {
+    std::vector<::CVC4::api::Term> cvc4assumps;
+    cvc4assumps.reserve(assumptions.size());
+
+    std::shared_ptr<CVC4Term> cterm;
+    for (auto a : assumptions)
     {
-      return Result(UNSAT);
+      cvc4assumps.push_back(std::static_pointer_cast<CVC4Term>(a)->term);
     }
-    else if (r.isSat())
-    {
-      return Result(SAT);
-    }
-    else if (r.isSatUnknown())
-    {
-      return Result(UNKNOWN, r.getUnknownExplanation());
-    }
-    else
-    {
-      throw NotImplementedException("Unimplemented result type from CVC4");
-    }
+    return check_sat_assuming(cvc4assumps);
   }
   catch (::CVC4::api::CVC4ApiException & e)
   {

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -312,6 +312,26 @@ Result CVC4Solver::check_sat_assuming_list(const TermList & assumptions)
   }
 }
 
+Result CVC4Solver::check_sat_assuming_set(const UnorderedTermSet & assumptions)
+{
+  try
+  {
+    std::vector<::CVC4::api::Term> cvc4assumps;
+    cvc4assumps.reserve(assumptions.size());
+
+    std::shared_ptr<CVC4Term> cterm;
+    for (auto a : assumptions)
+    {
+      cvc4assumps.push_back(std::static_pointer_cast<CVC4Term>(a)->term);
+    }
+    return check_sat_assuming(cvc4assumps);
+  }
+  catch (::CVC4::api::CVC4ApiException & e)
+  {
+    throw InternalSolverException(e.what());
+  }
+}
+
 void CVC4Solver::push(uint64_t num)
 {
   try

--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -84,6 +84,7 @@ class LoggingSolver : public AbsSmtSolver
   void assert_formula(const Term & t) override;
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
+  Result check_sat_assuming_list(const TermList & assumptions) override;
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   void reset_assertions() override;

--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -85,6 +85,7 @@ class LoggingSolver : public AbsSmtSolver
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
   Result check_sat_assuming_list(const TermList & assumptions) override;
+  Result check_sat_assuming_set(const UnorderedTermSet & assumptions) override;
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   void reset_assertions() override;

--- a/include/solver.h
+++ b/include/solver.h
@@ -73,6 +73,8 @@ class AbsSmtSolver
    */
   virtual Result check_sat_assuming(const TermVec & assumptions) = 0;
 
+  virtual Result check_sat_assuming_list(const TermList & assumptions);
+
   /* Push contexts
    * SMTLIB: (push <num>)
    * @param num the number of contexts to push

--- a/include/solver.h
+++ b/include/solver.h
@@ -75,6 +75,8 @@ class AbsSmtSolver
 
   virtual Result check_sat_assuming_list(const TermList & assumptions);
 
+  virtual Result check_sat_assuming_set(const UnorderedTermSet & assumptions);
+
   /* Push contexts
    * SMTLIB: (push <num>)
    * @param num the number of contexts to push

--- a/include/term.h
+++ b/include/term.h
@@ -18,6 +18,7 @@
 
 #include <iostream>
 #include <iterator>
+#include <list>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -166,6 +167,7 @@ class TermIter
 
 // useful typedefs for data structures
 using TermVec = std::vector<Term>;
+using TermList = std::list<Term>;
 using UnorderedTermSet = std::unordered_set<Term>;
 using UnorderedTermMap = std::unordered_map<Term, Term>;
 // range-based iteration

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -72,6 +72,7 @@ class MsatSolver : public AbsSmtSolver
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
   Result check_sat_assuming_list(const TermList & assumptions) override;
+  Result check_sat_assuming_set(const UnorderedTermSet & assumptions) override;
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   Term get_value(const Term & t) const override;

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -158,29 +158,6 @@ class MsatSolver : public AbsSmtSolver
       return Result(UNKNOWN);
     }
   }
-
-  template <class I>
-  inline void all_boolean_literals(I it, const I & end)
-  {
-    while (it != end)
-    {
-      const Term & a = *it;
-      it++;
-      if (!a->is_symbolic_const() || a->get_sort()->get_sort_kind() != BOOL)
-      {
-        if (a->get_op() == Not && (*a->begin())->is_symbolic_const())
-        {
-          continue;
-        }
-        else
-        {
-          throw IncorrectUsageException(
-              "Expecting boolean indicator literals but got: "
-              + a->to_string());
-        }
-      }
-    }
-  }
 };
 
 // Interpolating Solver

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -265,6 +265,38 @@ Result MsatSolver::check_sat_assuming_list(const TermList & assumptions)
   return check_sat_assuming(m_assumps);
 }
 
+Result MsatSolver::check_sat_assuming_set(const UnorderedTermSet & assumptions)
+{
+  // expecting (possibly negated) boolean literals
+  for (const auto & a : assumptions)
+  {
+    if (!a->is_symbolic_const() || a->get_sort()->get_sort_kind() != BOOL)
+    {
+      if (a->get_op() == Not && (*a->begin())->is_symbolic_const())
+      {
+        continue;
+      }
+      else
+      {
+        throw IncorrectUsageException(
+            "Expecting boolean indicator literals but got: " + a->to_string());
+      }
+    }
+  }
+
+  vector<msat_term> m_assumps;
+  m_assumps.reserve(assumptions.size());
+
+  shared_ptr<MsatTerm> ma;
+  for (const auto & a : assumptions)
+  {
+    ma = static_pointer_cast<MsatTerm>(a);
+    m_assumps.push_back(ma->term);
+  }
+
+  return check_sat_assuming(m_assumps);
+}
+
 void MsatSolver::push(uint64_t num)
 {
   for (uint64_t i = 0; i < num; i++)

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -204,7 +204,21 @@ Result MsatSolver::check_sat()
 Result MsatSolver::check_sat_assuming(const TermVec & assumptions)
 {
   // expecting (possibly negated) boolean literals
-  all_boolean_literals(assumptions.begin(), assumptions.end());
+  for (const auto & a : assumptions)
+  {
+    if (!a->is_symbolic_const() || a->get_sort()->get_sort_kind() != BOOL)
+    {
+      if (a->get_op() == Not && (*a->begin())->is_symbolic_const())
+      {
+        continue;
+      }
+      else
+      {
+        throw IncorrectUsageException(
+            "Expecting boolean indicator literals but got: " + a->to_string());
+      }
+    }
+  }
 
   vector<msat_term> m_assumps;
   m_assumps.reserve(assumptions.size());
@@ -222,7 +236,21 @@ Result MsatSolver::check_sat_assuming(const TermVec & assumptions)
 Result MsatSolver::check_sat_assuming_list(const TermList & assumptions)
 {
   // expecting (possibly negated) boolean literals
-  all_boolean_literals(assumptions.begin(), assumptions.end());
+  for (const auto & a : assumptions)
+  {
+    if (!a->is_symbolic_const() || a->get_sort()->get_sort_kind() != BOOL)
+    {
+      if (a->get_op() == Not && (*a->begin())->is_symbolic_const())
+      {
+        continue;
+      }
+      else
+      {
+        throw IncorrectUsageException(
+            "Expecting boolean indicator literals but got: " + a->to_string());
+      }
+    }
+  }
 
   vector<msat_term> m_assumps;
   m_assumps.reserve(assumptions.size());

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -204,47 +204,37 @@ Result MsatSolver::check_sat()
 Result MsatSolver::check_sat_assuming(const TermVec & assumptions)
 {
   // expecting (possibly negated) boolean literals
-  for (auto a : assumptions)
-  {
-    if (!a->is_symbolic_const() || a->get_sort()->get_sort_kind() != BOOL)
-    {
-      if (a->get_op() == Not && (*a->begin())->is_symbolic_const())
-      {
-        continue;
-      }
-      else
-      {
-        throw IncorrectUsageException(
-            "Expecting boolean indicator literals but got: " + a->to_string());
-      }
-    }
-  }
+  all_boolean_literals(assumptions.begin(), assumptions.end());
 
   vector<msat_term> m_assumps;
   m_assumps.reserve(assumptions.size());
 
   shared_ptr<MsatTerm> ma;
-  for (auto a : assumptions)
+  for (const auto & a : assumptions)
   {
     ma = static_pointer_cast<MsatTerm>(a);
     m_assumps.push_back(ma->term);
   }
 
-  msat_result mres =
-      msat_solve_with_assumptions(env, &m_assumps[0], m_assumps.size());
+  return check_sat_assuming(m_assumps);
+}
 
-  if (mres == MSAT_SAT)
+Result MsatSolver::check_sat_assuming_list(const TermList & assumptions)
+{
+  // expecting (possibly negated) boolean literals
+  all_boolean_literals(assumptions.begin(), assumptions.end());
+
+  vector<msat_term> m_assumps;
+  m_assumps.reserve(assumptions.size());
+
+  shared_ptr<MsatTerm> ma;
+  for (const auto & a : assumptions)
   {
-    return Result(SAT);
+    ma = static_pointer_cast<MsatTerm>(a);
+    m_assumps.push_back(ma->term);
   }
-  else if (mres == MSAT_UNSAT)
-  {
-    return Result(UNSAT);
-  }
-  else
-  {
-    return Result(UNKNOWN);
-  }
+
+  return check_sat_assuming(m_assumps);
 }
 
 void MsatSolver::push(uint64_t num)

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -595,6 +595,22 @@ Result LoggingSolver::check_sat_assuming(const TermVec & assumptions)
   return wrapped_solver->check_sat_assuming(lassumps);
 }
 
+Result LoggingSolver::check_sat_assuming_list(const TermList & assumptions)
+{
+  // only needs to remember the latest set of assumptions
+  assumption_cache->clear();
+  TermList lassumps;
+  shared_ptr<LoggingTerm> la;
+  for (auto a : assumptions)
+  {
+    la = static_pointer_cast<LoggingTerm>(a);
+    lassumps.push_back(la->wrapped_term);
+    // store a mapping from the wrapped term to the logging term
+    (*assumption_cache)[la->wrapped_term] = la;
+  }
+  return wrapped_solver->check_sat_assuming_list(lassumps);
+}
+
 void LoggingSolver::push(uint64_t num) { wrapped_solver->push(num); }
 
 void LoggingSolver::pop(uint64_t num) { wrapped_solver->pop(num); }

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -611,6 +611,23 @@ Result LoggingSolver::check_sat_assuming_list(const TermList & assumptions)
   return wrapped_solver->check_sat_assuming_list(lassumps);
 }
 
+Result LoggingSolver::check_sat_assuming_set(
+    const UnorderedTermSet & assumptions)
+{
+  // only needs to remember the latest set of assumptions
+  assumption_cache->clear();
+  UnorderedTermSet lassumps;
+  shared_ptr<LoggingTerm> la;
+  for (auto a : assumptions)
+  {
+    la = static_pointer_cast<LoggingTerm>(a);
+    lassumps.insert(la->wrapped_term);
+    // store a mapping from the wrapped term to the logging term
+    (*assumption_cache)[la->wrapped_term] = la;
+  }
+  return wrapped_solver->check_sat_assuming_set(lassumps);
+}
+
 void LoggingSolver::push(uint64_t num) { wrapped_solver->push(num); }
 
 void LoggingSolver::pop(uint64_t num) { wrapped_solver->pop(num); }

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -23,6 +23,12 @@ namespace smt {
 
 // TODO: Implement a generic visitor
 
+Result AbsSmtSolver::check_sat_assuming_list(const TermList & assumptions)
+{
+  throw NotImplementedException(
+      "check_sat_assuming_list not implemented by default");
+}
+
 Term AbsSmtSolver::substitute(const Term term,
                               const UnorderedTermMap & substitution_map) const
 {

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -29,6 +29,13 @@ Result AbsSmtSolver::check_sat_assuming_list(const TermList & assumptions)
       "check_sat_assuming_list not implemented by default");
 }
 
+Result AbsSmtSolver::check_sat_assuming_set(
+    const UnorderedTermSet & assumptions)
+{
+  throw NotImplementedException(
+      "check_sat_assuming_set not implemented by default");
+}
+
 Term AbsSmtSolver::substitute(const Term term,
                               const UnorderedTermMap & substitution_map) const
 {

--- a/tests/unit/unit-solving-interface.cpp
+++ b/tests/unit/unit-solving-interface.cpp
@@ -69,7 +69,10 @@ TEST_P(UnitSolveTests, CheckSatAssuming)
     EXPECT_EQ(s->get_solver_enum(), MSAT);
     r = s->check_sat_assuming(TermVec{ b1, nb2 });
   }
-  ASSERT_TRUE(r.is_unsat());
+  EXPECT_TRUE(r.is_unsat());
+
+  r = s->check_sat_assuming_list(TermList{ b1, nb2 });
+  EXPECT_TRUE(r.is_unsat());
 }
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSolveTests,

--- a/tests/unit/unit-solving-interface.cpp
+++ b/tests/unit/unit-solving-interface.cpp
@@ -73,6 +73,9 @@ TEST_P(UnitSolveTests, CheckSatAssuming)
 
   r = s->check_sat_assuming_list(TermList{ b1, nb2 });
   EXPECT_TRUE(r.is_unsat());
+
+  r = s->check_sat_assuming_set(UnorderedTermSet{ b1, nb2 });
+  EXPECT_TRUE(r.is_unsat());
 }
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSolveTests,

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -64,6 +64,7 @@ class Yices2Solver : public AbsSmtSolver
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
   Result check_sat_assuming_list(const TermList & assumptions) override;
+  Result check_sat_assuming_set(const UnorderedTermSet & assumptions) override;
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   Term get_value(const Term & t) const override;

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -63,6 +63,7 @@ class Yices2Solver : public AbsSmtSolver
   void assert_formula(const Term & t) override;
   Result check_sat() override;
   Result check_sat_assuming(const TermVec & assumptions) override;
+  Result check_sat_assuming_list(const TermList & assumptions) override;
   void push(uint64_t num = 1) override;
   void pop(uint64_t num = 1) override;
   Term get_value(const Term & t) const override;
@@ -119,6 +120,32 @@ class Yices2Solver : public AbsSmtSolver
  protected:
   mutable context_t * ctx;
   mutable ctx_config_t * config;
+
+  // helper function
+  inline Result check_sat_assuming(const std::vector<term_t> & y_assumps)
+  {
+    smt_status_t res = yices_check_context_with_assumptions(
+        ctx, NULL, y_assumps.size(), &y_assumps[0]);
+
+    if (yices_error_code() != 0)
+    {
+      std::string msg(yices_error_string());
+      throw InternalSolverException(msg.c_str());
+    }
+
+    if (res == STATUS_SAT)
+    {
+      return Result(SAT);
+    }
+    else if (res == STATUS_UNSAT)
+    {
+      return Result(UNSAT);
+    }
+    else
+    {
+      return Result(UNKNOWN);
+    }
+  }
 };
 }  // namespace smt
 

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -349,6 +349,22 @@ Result Yices2Solver::check_sat_assuming_list(const TermList & assumptions)
   return check_sat_assuming(y_assumps);
 }
 
+Result Yices2Solver::check_sat_assuming_set(
+    const UnorderedTermSet & assumptions)
+{
+  vector<term_t> y_assumps;
+  y_assumps.reserve(assumptions.size());
+
+  shared_ptr<Yices2Term> ya;
+  for (auto a : assumptions)
+  {
+    ya = static_pointer_cast<Yices2Term>(a);
+    y_assumps.push_back(ya->term);
+  }
+
+  return check_sat_assuming(y_assumps);
+}
+
 void Yices2Solver::push(uint64_t num) { yices_push(ctx); }
 
 void Yices2Solver::pop(uint64_t num) { yices_pop(ctx); }

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -331,27 +331,22 @@ Result Yices2Solver::check_sat_assuming(const TermVec & assumptions)
     y_assumps.push_back(ya->term);
   }
 
-  smt_status_t res = yices_check_context_with_assumptions(
-      ctx, NULL, y_assumps.size(), &y_assumps[0]);
+  return check_sat_assuming(y_assumps);
+}
 
-  if (yices_error_code() != 0)
+Result Yices2Solver::check_sat_assuming_list(const TermList & assumptions)
+{
+  vector<term_t> y_assumps;
+  y_assumps.reserve(assumptions.size());
+
+  shared_ptr<Yices2Term> ya;
+  for (auto a : assumptions)
   {
-    std::string msg(yices_error_string());
-    throw InternalSolverException(msg.c_str());
+    ya = static_pointer_cast<Yices2Term>(a);
+    y_assumps.push_back(ya->term);
   }
 
-  if (res == STATUS_SAT)
-  {
-    return Result(SAT);
-  }
-  else if (res == STATUS_UNSAT)
-  {
-    return Result(UNSAT);
-  }
-  else
-  {
-    return Result(UNKNOWN);
-  }
+  return check_sat_assuming(y_assumps);
 }
 
 void Yices2Solver::push(uint64_t num) { yices_push(ctx); }


### PR DESCRIPTION
Adds basic support for a `check_sat_assuming` method that takes a list. Because of ambiguity with brace-enclosed lists, this function needs to have a different name. Furthermore, it would be nice if the code could be the same for both cases, but this requires templates and that doesn't work with virtual functions. For now this should work and it can be improved in the future.

The use case is for quick iterations of `check_sat_assuming_list` calls because it is faster to remove elements from a list.