### PR TITLE
Fix for check_sortedness of equality between arithmetic sorts

### DIFF
--- a/include/sort_inference.h
+++ b/include/sort_inference.h
@@ -99,6 +99,15 @@ bool check_quantifier_terms(const TermVec & terms);
  */
 bool equal_sorts(const SortVec & sorts);
 
+/** Weaker version of equal_sorts
+ *  Checks that the sorts are either equivalent
+ *  or at least all arithmetic sorts (e.g. real
+ *  and integer).
+ *  @return true iff they're all arithmetic sorts
+ *          or exactly the same sort
+ */
+bool arith_equal_sorts(const SortVec & sorts);
+
 /** Checks that the sorts have the same SortKind
  *  @param sorts a non-empty vector of sorts
  *  @return true iff they're all equal

--- a/include/sort_inference.h
+++ b/include/sort_inference.h
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include "assert.h"
+#include <unordered_set>
 
+#include "assert.h"
 #include "ops.h"
 #include "solver.h"
 #include "sort.h"
@@ -126,6 +127,14 @@ bool check_ite_sorts(const SortVec & sorts);
  *  @return true iff all SortKinds have sort sk
  */
 bool check_sortkind_matches(SortKind sk, const SortVec & sorts);
+
+/** Returns true iff all the sorts have SortKind in sks
+ *  @param sks the set of possible SortKinds
+ *  @param sorts the vector of Sorts to check
+ *  @return true iff all sorts have SortKind in sks
+ */
+bool check_one_of_sortkinds(const std::unordered_set<SortKind> & sks,
+                            const SortVec & sorts);
 
 /** Checks if the sorts are well-sorted for an apply operator
  *  @param sorts the vector of sorts

--- a/src/sort_inference.cpp
+++ b/src/sort_inference.cpp
@@ -307,6 +307,19 @@ bool check_sortkind_matches(SortKind sk, const SortVec & sorts)
   return true;
 }
 
+bool check_one_of_sortkinds(const unordered_set<SortKind> & sks,
+                            const SortVec & sorts)
+{
+  for (auto sort : sorts)
+  {
+    if (sks.find(sort->get_sort_kind()) == sks.end())
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
 bool check_apply_sorts(const SortVec & sorts)
 {
   assert(sorts.size());
@@ -409,8 +422,7 @@ bool int_sorts(const SortVec & sorts)
 
 bool arithmetic_sorts(const SortVec & sorts)
 {
-  return check_sortkind_matches(INT, sorts)
-         || check_sortkind_matches(REAL, sorts);
+  return check_one_of_sortkinds({ INT, REAL }, sorts);
 }
 
 bool array_sorts(const SortVec & sorts)

--- a/src/sort_inference.cpp
+++ b/src/sort_inference.cpp
@@ -34,8 +34,8 @@ const std::unordered_map<PrimOp, std::function<bool(const SortVec & sorts)>>
                           { Not, bool_sorts },
                           { Implies, bool_sorts },
                           { Ite, check_ite_sorts },
-                          { Equal, equal_sorts },
-                          { Distinct, equal_sorts },
+                          { Equal, arith_equal_sorts },
+                          { Distinct, arith_equal_sorts },
                           { Apply, check_apply_sorts },
                           { Plus, arithmetic_sorts },
                           { Minus, arithmetic_sorts },
@@ -268,6 +268,11 @@ bool equal_sorts(const SortVec & sorts)
   assert(sorts.size());
   return (adjacent_find(sorts.begin(), sorts.end(), not_equal_to<Sort>())
           == sorts.end());
+}
+
+bool arith_equal_sorts(const SortVec & sorts)
+{
+  return equal_sorts(sorts) || arithmetic_sorts(sorts);
 }
 
 bool equal_sortkinds(const SortVec & sorts)


### PR DESCRIPTION
This PR allows comparing reals to integers with `Equal` and `Distinct`