### PR TITLE
Generic Solver: Refactoring + bugfix

### DIFF
--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -117,6 +117,21 @@ class GenericSolver : public AbsSmtSolver
   /******************
    * helper methods *
    *******************/
+
+  /** a helper function for the corresponding make_term
+   * function with the same arguments.
+   * Also used to parse get_value responses.
+   */
+  Term make_value(int64_t i, const Sort & sort) const;
+
+  /** a helper function for the corresponding make_term
+   * function with the same arguments.
+   * Also used to parse get_value responses.
+   */
+  Term make_value(const std::string val,
+                  const Sort & sort,
+                  uint64_t base = 10) const;
+
   // returns a string representation of a term in smtlib
   std::string to_smtlib_def(Term term) const;
 

--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -118,16 +118,12 @@ class GenericSolver : public AbsSmtSolver
    * helper methods *
    *******************/
 
-  /** a helper function for the corresponding make_term
-   * function with the same arguments.
+  /** Helper functions for the corresponding make_term
+   * functions with the same arguments.
    * Also used to parse get_value responses.
    */
+  Term make_value(bool b) const;
   Term make_value(int64_t i, const Sort & sort) const;
-
-  /** a helper function for the corresponding make_term
-   * function with the same arguments.
-   * Also used to parse get_value responses.
-   */
   Term make_value(const std::string val,
                   const Sort & sort,
                   uint64_t base = 10) const;

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -599,11 +599,17 @@ Term GenericSolver::make_negative_bv_const(int64_t abs_value, uint width) const
 
 Term GenericSolver::make_term(bool b) const
 {
+  Term value_term = make_value(b);
+  return store_term(value_term);
+}
+
+Term GenericSolver::make_value(bool b) const
+{
   // create a generic term that represents `b`.
   Sort boolsort = make_sort(BOOL);
   Term term = std::make_shared<GenericTerm>(
       boolsort, Op(), TermVec{}, b ? "true" : "false");
-  return store_term(term);
+  return term;
 }
 
 Term GenericSolver::make_term(int64_t i, const Sort & sort) const
@@ -830,6 +836,12 @@ Term GenericSolver::get_value(const Term & t) const
           value.substr(start_of_decimal, end_of_decimal - start_of_decimal + 1);
       resulting_term = make_value(decimal, sort, 10);
     }
+  }
+  else if (sort->get_sort_kind() == BOOL)
+  {
+    Assert(value == "true" || value == "false");
+    bool b = (value == "true");
+    resulting_term = make_value(b);
   }
   else
   {

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -493,7 +493,8 @@ void test_int_models(SmtSolver gs)
   gs->assert_formula(for1);
   Result result = gs->check_sat();
   assert(result.is_sat());
-  Term val = gs->get_value(i1);
+  Term val1 = gs->get_value(i1);
+  Term val2 = gs->get_value(for1);
   gs->pop(1);
 }
 


### PR DESCRIPTION
This PR refactors the creation of values, by separating it to two parts:
1. Creation of a GenericTerm object that represents a value.
2. Sending a define-fun command to the solver's binary with the created value.

This actually solves a bug: when creating a Term from the result of a `get-value`, we used to send a `define-fun` command to the solver with that value. This took the solver out of `sat` state, and then we couldn't perform another `get-value`. This is now fixed, and the test file is extended to test this scenario.

In addition, we now support get-value for Booleans, which we should. This is also tested by the same test now.