### PR TITLE
checking errors and fixes

### DIFF
--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -131,6 +131,15 @@ class GenericSolver : public AbsSmtSolver
   // returns a string representation of a term in smtlib
   std::string to_smtlib_def(Term term) const;
 
+  // when an SMT-LIB compliant solver is supposed
+  // to return a result (e.g., get-value),
+  // a result that starts with "(error " indicates
+  // that an error occurred.
+  // This cannot be caught by print-success,
+  // which is not utilized for commands that
+  // expect a result.
+  void check_no_error(std::string str) const;
+
   // parse solver's response from get-sat-assumptions
   UnorderedTermSet get_assumptions_from_string(std::string result) const;
 

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -806,6 +806,10 @@ Term GenericSolver::get_value(const Term & t) const
 
   // ask the binary for the value and parse it
   string result = run_command("(" + GET_VALUE_STR + " (" + name + "))", false);
+
+  // check that there was no error
+  check_no_error(result);
+
   string value = strip_value_from_result(result);
 
   // translate the string representation of the result into a term
@@ -894,11 +898,24 @@ void GenericSolver::get_unsat_core(UnorderedTermSet & out)
   // run get-unsat-assumptions command
   string result = run_command("(" + GET_UNSAT_ASSUMPTIONS_STR + ")", false);
 
+  // check that there was no error
+  check_no_error(result);
+
   // parse the result -- get the assumptions
   UnorderedTermSet assumptions = get_assumptions_from_string(result);
 
   // put the result in out
   out.insert(assumptions.begin(), assumptions.end());
+}
+
+void GenericSolver::check_no_error(string str) const
+{
+  str = trim(str);
+  string err_prefix("(error ");
+  if (str.compare(0, err_prefix.size(), err_prefix) == 0)
+  {
+    throw SmtException("Exception from the solver: " + str);
+  }
 }
 
 UnorderedTermSet GenericSolver::get_assumptions_from_string(string result) const

--- a/src/generic_term.cpp
+++ b/src/generic_term.cpp
@@ -154,7 +154,18 @@ bool GenericTerm::is_ground() const { return ground; }
 
 uint64_t GenericTerm::to_int() const { assert(false); }
 
-std::string GenericTerm::print_value_as(SortKind sk) { assert(false); }
+std::string GenericTerm::print_value_as(SortKind sk)
+{
+  if (is_value())
+  {
+    return to_string();
+  }
+  else
+  {
+    throw IncorrectUsageException(
+        "print_value_as is only applicable for values");
+  }
+}
 
 /* GenericTermIter */
 

--- a/src/ops.cpp
+++ b/src/ops.cpp
@@ -84,7 +84,7 @@ const std::unordered_map<PrimOp, std::string> primop2str(
       { Rotate_Left, "rotate_left" },
       { Rotate_Right, "rotate_right" },
       { BV_To_Nat, "bv2nat" },
-      { Int_To_BV, "nat2bv" },
+      { Int_To_BV, "int2bv" },
       { Select, "select" },
       { Store, "store" },
       { Forall, "forall" },


### PR DESCRIPTION
1. checking that the result from the solver does not indicate an error, and throwing an exception otherwise.
2. adding support for `print_value_as`
3. changing the string representation of `Int_To_BV` to conform with the way `CVC4` parses it.

Tests are not added, because these features are not consistent between solvers. All three changes will be tested in a future PR, when we add a CVC4-based generic solver to the available solvers for testing.