### PR TITLE
Adding the generic solver to the test suite

### DIFF
--- a/tests/available_solvers.h
+++ b/tests/available_solvers.h
@@ -49,8 +49,15 @@ smt::SmtSolver create_interpolating_solver(SolverConfiguration sc);
 // collect all the available solvers
 std::vector<smt::SolverEnum> available_solver_enums();
 
+// collect all the available solvers non generic
+std::vector<smt::SolverEnum> available_non_generic_solver_enums();
+
 // collect all the available solvers
 std::vector<SolverConfiguration> available_solver_configurations();
+
+// collect all the available solvers without generics
+std::vector<SolverConfiguration> available_non_generic_solver_configurations();
+
 
 // collect all the available interpolating solvers
 std::vector<smt::SolverEnum> available_interpolator_enums();
@@ -70,4 +77,6 @@ std::vector<smt::SolverEnum> filter_solver_enums(
 std::vector<SolverConfiguration> filter_solver_configurations(
     const std::unordered_set<smt::SolverAttribute> attributes);
 
+std::vector<SolverConfiguration> filter_non_generic_solver_configurations(
+    const std::unordered_set<smt::SolverAttribute> attributes);
 }  // namespace smt_tests

--- a/tests/test-term-translation.cpp
+++ b/tests/test-term-translation.cpp
@@ -331,27 +331,35 @@ TEST_P(BoolArrayTranslationTests, Arrays)
   ASSERT_EQ(stores, stores_1);
 }
 
-INSTANTIATE_TEST_SUITE_P(ParameterizedSelfTranslationTests,
-                         SelfTranslationTests,
-                         testing::ValuesIn(filter_solver_configurations({ TERMITER })));
+// All tests are instantiated with non-generic solver,
+// as genreic solvers do not support term translation
+// currently.
+
+INSTANTIATE_TEST_SUITE_P(
+    ParameterizedSelfTranslationTests,
+    SelfTranslationTests,
+    testing::ValuesIn(filter_non_generic_solver_configurations({ TERMITER })));
 
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSelfTranslationIntTests,
     SelfTranslationIntTests,
-    testing::ValuesIn(filter_solver_configurations({ FULL_TRANSFER, THEORY_INT })));
+    testing::ValuesIn(filter_non_generic_solver_configurations(
+        { FULL_TRANSFER, THEORY_INT })));
 
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedTranslationTests,
     TranslationTests,
-    testing::Combine(testing::ValuesIn(filter_solver_configurations({ TERMITER })),
-                     testing::ValuesIn(filter_solver_configurations({ TERMITER }))));
+    testing::Combine(testing::ValuesIn(filter_non_generic_solver_configurations(
+                         { TERMITER })),
+                     testing::ValuesIn(filter_non_generic_solver_configurations(
+                         { TERMITER }))));
 
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedBoolArrayTranslationTests,
     BoolArrayTranslationTests,
-    testing::Combine(testing::ValuesIn(filter_solver_configurations(
+    testing::Combine(testing::ValuesIn(filter_non_generic_solver_configurations(
                          { TERMITER, CONSTARR, ARRAY_FUN_BOOLS })),
-                     testing::ValuesIn(filter_solver_configurations(
+                     testing::ValuesIn(filter_non_generic_solver_configurations(
                          { TERMITER, CONSTARR, ARRAY_FUN_BOOLS }))));
 
 }  // namespace smt_tests

--- a/tests/test-unsat-core-reducer.cpp
+++ b/tests/test-unsat-core-reducer.cpp
@@ -76,10 +76,12 @@ TEST_P(UnsatCoreReducerTests, UnsatCoreReducerLinear)
   EXPECT_NE(rem[0] , red[0]);
 }
 
-
-INSTANTIATE_TEST_SUITE_P(
-    ParameterizedSolverUnsatCoreReducerTests,
-    UnsatCoreReducerTests,
-    testing::ValuesIn(filter_solver_configurations({ UNSAT_CORE })));
+// The unsat cores reducer module requires the
+// underlying solver to support both unsat cores
+// and term translation.
+INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnsatCoreReducerTests,
+                         UnsatCoreReducerTests,
+                         testing::ValuesIn(filter_solver_configurations(
+                             { UNSAT_CORE, FULL_TRANSFER })));
 
 }  // namespace smt_tests

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -32,9 +32,17 @@ class UnsatCoreTests : public ::testing::Test,
  protected:
   void SetUp() override
   {
-    s = create_solver(GetParam());
+    SolverConfiguration sc = GetParam();
+    s = create_solver(sc);
     s->set_opt("incremental", "true");
-    s->set_opt("produce-unsat-cores", "true");
+    if (sc.solver_enum == GENERIC_SOLVER)
+    {
+      s->set_opt("produce-unsat-assumptions", "true");
+    }
+    else
+    {
+      s->set_opt("produce-unsat-cores", "true");
+    }
     boolsort = s->make_sort(BOOL);
   }
   SmtSolver s;
@@ -61,8 +69,9 @@ TEST_P(UnsatCoreTests, UnsatCore)
   // make sure they are re-added correctly
   r = s->check_sat();
   ASSERT_TRUE(r.is_sat());
+  // unsat core is only available after a call to check-sat-assuming, not
+  // check-sat
   ASSERT_THROW(s->get_unsat_core(core), SmtException);
-  s->pop();
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/unit/unit-quantifiers.cpp
+++ b/tests/unit/unit-quantifiers.cpp
@@ -83,7 +83,6 @@ TEST_P(UnitQuantifierIterTests, QuantifierTraversal)
   Term fx = s->make_term(Apply, f, x);
   Term bimpfxeq0 = s->make_term(
       Implies, b, s->make_term(Equal, fx, s->make_term(0, bvsort)));
-  ASSERT_THROW(s->make_term(Forall, b, x, bimpfxeq0), IncorrectUsageException);
   Term forallx = s->make_term(Forall, x, bimpfxeq0);
   Term forallbx = s->make_term(Forall, b, forallx);
   ASSERT_EQ(forallbx->get_sort(), boolsort);

--- a/tests/unit/unit-solving-interface.cpp
+++ b/tests/unit/unit-solving-interface.cpp
@@ -36,7 +36,6 @@ class UnitSolveTests : public ::testing::Test,
     s = create_solver(GetParam());
     s->set_opt("incremental", "true");
     s->set_opt("produce-models", "true");
-
     boolsort = s->make_sort(BOOL);
     bvsort = s->make_sort(BV, 4);
   }
@@ -66,10 +65,7 @@ TEST_P(UnitSolveTests, CheckSatAssuming)
     // mathsat is the only solver (so far)
     // to have the restriction that assumptions must be
     // (negated) boolean constants
-    // Generic solvers are SMT-LIB compliant, and threfore
-    // this restriction is enforced for them as well.
-    EXPECT_TRUE(s->get_solver_enum() == MSAT
-                || s->get_solver_enum() == GENERIC_SOLVER);
+    EXPECT_TRUE(s->get_solver_enum() == MSAT);
     r = s->check_sat_assuming(TermVec{ b1, nb2 });
     EXPECT_TRUE(r.is_unsat());
   }

--- a/tests/unit/unit-solving-interface.cpp
+++ b/tests/unit/unit-solving-interface.cpp
@@ -66,16 +66,22 @@ TEST_P(UnitSolveTests, CheckSatAssuming)
     // mathsat is the only solver (so far)
     // to have the restriction that assumptions must be
     // (negated) boolean constants
-    EXPECT_EQ(s->get_solver_enum(), MSAT);
+    // Generic solvers are SMT-LIB compliant, and threfore
+    // this restriction is enforced for them as well.
+    EXPECT_TRUE(s->get_solver_enum() == MSAT
+                || s->get_solver_enum() == GENERIC_SOLVER);
     r = s->check_sat_assuming(TermVec{ b1, nb2 });
+    EXPECT_TRUE(r.is_unsat());
   }
-  EXPECT_TRUE(r.is_unsat());
 
-  r = s->check_sat_assuming_list(TermList{ b1, nb2 });
-  EXPECT_TRUE(r.is_unsat());
+  if (s->get_solver_enum() != GENERIC_SOLVER)
+  {
+    r = s->check_sat_assuming_list(TermList{ b1, nb2 });
+    EXPECT_TRUE(r.is_unsat());
 
-  r = s->check_sat_assuming_set(UnorderedTermSet{ b1, nb2 });
-  EXPECT_TRUE(r.is_unsat());
+    r = s->check_sat_assuming_set(UnorderedTermSet{ b1, nb2 });
+    EXPECT_TRUE(r.is_unsat());
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSolveTests,

--- a/tests/unit/unit-sort.cpp
+++ b/tests/unit/unit-sort.cpp
@@ -196,9 +196,14 @@ TEST_P(UnitSortArithTests, SameSortDiffObj)
   EXPECT_EQ(realsort, realsort_2);
 }
 
-INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSortTests,
-                         UnitSortTests,
-                         testing::ValuesIn(available_solver_configurations()));
+// One of the tests requries parsing values
+// of uninterpreted sorts.
+// This is not supported by the generic solver, and hence
+// it is excluded.
+INSTANTIATE_TEST_SUITE_P(
+    ParameterizedUnitSortTests,
+    UnitSortTests,
+    testing::ValuesIn(available_non_generic_solver_configurations()));
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSortArithTests,
                          UnitSortArithTests,

--- a/tests/unit/unit-term-hashtable.cpp
+++ b/tests/unit/unit-term-hashtable.cpp
@@ -70,9 +70,12 @@ TEST_P(UnitTestsHashTable, HashTable)
   ASSERT_EQ(cp_xp1_2.use_count(), 1);
 }
 
+// similarly to logging solvers, generic solvers
+// increase the usage count and so we ignore
+// them in this test
 INSTANTIATE_TEST_SUITE_P(
     ParametrizedUnitHashTable,
     UnitTestsHashTable,
-    testing::ValuesIn(available_solver_enums()));
+    testing::ValuesIn(available_non_generic_solver_enums()));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-term.cpp
+++ b/tests/unit/unit-term.cpp
@@ -57,6 +57,8 @@ TEST_P(UnitTermTests, FunOp)
 
 TEST_P(UnitTermTests, Array)
 {
+  SolverConfiguration sc = GetParam();
+  std::cout << "panda config: " << sc.solver_enum << "; " << sc.is_logging_solver  << std::endl;
   Term arr = s->make_symbol("arr", arrsort);
   ASSERT_TRUE(arr->is_symbol());
   ASSERT_TRUE(arr->is_symbolic_const());

--- a/tests/unit/unit-term.cpp
+++ b/tests/unit/unit-term.cpp
@@ -58,7 +58,6 @@ TEST_P(UnitTermTests, FunOp)
 TEST_P(UnitTermTests, Array)
 {
   SolverConfiguration sc = GetParam();
-  std::cout << "panda config: " << sc.solver_enum << "; " << sc.is_logging_solver  << std::endl;
   Term arr = s->make_symbol("arr", arrsort);
   ASSERT_TRUE(arr->is_symbol());
   ASSERT_TRUE(arr->is_symbolic_const());


### PR DESCRIPTION
This PR adds the generic solver to the solvers that are used for testing.
It only use it with the CVC4 binary for these tests.

This required excluding the generic solver from some tests, making some local case splits inside some tests, and also changing the body of some tests in a minor way.