### PR TITLE
Temporarily disable Z3 build

### DIFF
--- a/z3/CMakeLists.txt
+++ b/z3/CMakeLists.txt
@@ -1,3 +1,4 @@
+message(FATAL_ERROR "Z3 backend development is still in progress and not yet ready for use")
 add_library(smt-switch-z3 "${SMT_SWITCH_LIB_TYPE}"
   # "${CMAKE_CURRENT_SOURCE_DIR}/src/z3_extensions.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/z3_factory.cpp"


### PR DESCRIPTION
This PR temporarily disables the Z3 build while the Z3 backend is tested and the final features are being added. Once development is complete, it will be re-enabled.