### PR TITLE
Require Bison 3.7 + Bison/Flex convenience scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,8 @@ set(SOURCES
   "${PROJECT_SOURCE_DIR}/src/utils.cpp")
 
 if (SMTLIB_READER)
-  find_package(BISON 3.4.2 REQUIRED)
+  list(APPEND CMAKE_PREFIX_PATH "${PROJECT_SOURCE_DIR}/deps/bison/bison-install")
+  find_package(BISON 3.7.0 REQUIRED)
   find_package(FLEX 2.6.4 REQUIRED)
 
   if (BISON_FOUND)

--- a/contrib/setup-bison.sh
+++ b/contrib/setup-bison.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DEPS=$DIR/../deps
+
+mkdir -p $DEPS
+
+if [ -d "$DEPS/bison" ]; then
+    echo "It appears bison has already been downloaded to $DEPS/bison"
+    echo "If you'd like to rebuild, please delete it and run this script again"
+    exit 1
+fi
+
+curl http://ftp.gnu.org/gnu/bison/bison-3.7.tar.xz --output $DEPS/bison-3.7.tar.xz
+
+if [ ! -f "$DEPS/bison-3.7.tar.xz" ]; then
+    echo "It seems like downloading bison to $DEPS/bison-3.7.tar.xz failed"
+    exit 1
+fi
+
+cd $DEPS
+tar -xf bison-3.7.tar.xz
+rm bison-3.7.tar.xz
+mv ./bison-3.7 ./bison
+cd bison
+mkdir bison-install
+./configure --prefix $DEPS/bison/bison-install --exec-prefix $DEPS/bison/bison-install
+make -j$(nproc)
+make install
+cd $DIR
+
+if [ ! -f "$DEPS/bison/bison-install/bin/bison" ]; then
+    echo "It seems like installing bison to $DEPS/bison/bison-install failed"
+    exit 1
+fi

--- a/contrib/setup-flex.sh
+++ b/contrib/setup-flex.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DEPS=$DIR/../deps
+
+mkdir -p $DEPS
+
+if [ -d "$DEPS/flex" ]; then
+    echo "It appears flex has already been downloaded to $DEPS/flex"
+    echo "If you'd like to rebuild, please delete it and run this script again"
+    exit 1
+fi
+
+curl -Lk https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz --output $DEPS/flex-2.6.4.tar.gz
+
+if [ ! -f "$DEPS/flex-2.6.4.tar.gz" ]; then
+    echo "It seems like downloading flex to $DEPS/flex-2.6.4.tar.gz failed"
+    exit 1
+fi
+
+# Set CFLAGS to work around compiler issue with building flex
+export CFLAGS="$CFLAGS -D_GNU_SOURCE"
+cd $DEPS
+tar -xf flex-2.6.4.tar.gz
+rm flex-2.6.4.tar.gz
+mv flex-2.6.4 flex
+cd flex
+mkdir flex-install
+./configure --prefix $DEPS/flex/flex-install --exec-prefix $DEPS/flex/flex-install
+make -j$(nproc)
+make install
+cd $DIR
+
+if [ ! -f "$DEPS/flex/flex-install/bin/flex" ]; then
+    echo "It seems like installing flex to $DEPS/flex/flex-install failed"
+    exit 1
+fi


### PR DESCRIPTION
This PR updates the required bison version to 3.7 in the build system. This is to match the required version in the bison file. The PR also contains convenience scripts for bison and flex.