### PR TITLE
Rename: unsat-core -> unsat-assumptions

### DIFF
--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -64,7 +64,7 @@ class BoolectorSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(UnorderedTermSet & out) override;
+  void get_unsat_assumptions(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -108,7 +108,7 @@ void BoolectorSolver::set_opt(const std::string option, const std::string value)
   {
     if (value == "true")
     {
-      // needs to be incremental
+      // needs to be incremental for getting unsat assumptions
       boolector_set_opt(btor, BTOR_OPT_INCREMENTAL, 1);
     }
   }

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -104,7 +104,7 @@ void BoolectorSolver::set_opt(const std::string option, const std::string value)
       boolector_set_opt(btor, BTOR_OPT_INCREMENTAL, 1);
     }
   }
-  else if (option == "produce-unsat-cores")
+  else if (option == "produce-unsat-assumptions")
   {
     if (value == "true")
     {
@@ -475,7 +475,7 @@ UnorderedTermMap BoolectorSolver::get_array_values(const Term & arr,
   return assignments;
 }
 
-void BoolectorSolver::get_unsat_core(UnorderedTermSet & out)
+void BoolectorSolver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   BoolectorNode ** bcore = boolector_get_failed_assumptions(btor);
   while (*bcore)

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -63,7 +63,7 @@ class CVC4Solver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(UnorderedTermSet & out) override;
+  void get_unsat_assumptions(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -110,16 +110,7 @@ void CVC4Solver::set_opt(const std::string option, const std::string value)
 {
   try
   {
-    if (option == "produce-unsat-assumptions")
-    {
-      // to be consistent with the smt-switch API, we actually use
-      // produce-unsat-assumptions
-      solver.setOption("produce-unsat-assumptions", value);
-    }
-    else
-    {
-      solver.setOption(option, value);
-    }
+    solver.setOption(option, value);
   }
   catch (::CVC4::api::CVC4ApiException & e)
   {

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -110,7 +110,7 @@ void CVC4Solver::set_opt(const std::string option, const std::string value)
 {
   try
   {
-    if (option == "produce-unsat-cores")
+    if (option == "produce-unsat-assumptions")
     {
       // to be consistent with the smt-switch API, we actually use
       // produce-unsat-assumptions
@@ -417,7 +417,7 @@ UnorderedTermMap CVC4Solver::get_array_values(const Term & arr,
   }
 }
 
-void CVC4Solver::get_unsat_core(UnorderedTermSet & out)
+void CVC4Solver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   Term f;
   try

--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -98,7 +98,7 @@ class GenericSolver : public AbsSmtSolver
                  const Term & t2) const override;
   Term make_term(const Op op, const TermVec & terms) const override;
   Term get_value(const Term & t) const override;
-  void get_unsat_core(UnorderedTermSet & out) override;
+  void get_unsat_assumptions(UnorderedTermSet & out) override;
   // Will probably remove this eventually
   // For now, need to clear the hash table
   void reset() override;

--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -73,7 +73,7 @@ class LoggingSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(UnorderedTermSet & out) override;
+  void get_unsat_assumptions(UnorderedTermSet & out) override;
   // Will probably remove this eventually
   // For now, need to clear the hash table
   void reset() override;
@@ -96,7 +96,7 @@ class LoggingSolver : public AbsSmtSolver
   // stores a mapping from wrapped terms to logging terms
   // that were used in check_sat_assuming
   // this is so they can be recovered with the correct children/op
-  // after a call to get_unsat_core
+  // after a call to get_unsat_assumptions
   std::unique_ptr<UnorderedTermMap> assumption_cache;
 
   // NOTE this is a little ugly, but this needs to be incremented

--- a/include/printing_solver.h
+++ b/include/printing_solver.h
@@ -52,7 +52,7 @@ class PrintingSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(UnorderedTermSet & out) override;
+  void get_unsat_assumptions(UnorderedTermSet & out) override;
   void reset() override;
   void set_opt(const std::string option, const std::string value) override;
   void set_logic(const std::string logic) override;

--- a/include/solver.h
+++ b/include/solver.h
@@ -113,7 +113,7 @@ class AbsSmtSolver
    *  unsat.
    *  SMTLIB: (get-unsat-assumptions)
    */
-  virtual void get_unsat_core(UnorderedTermSet & out) = 0;
+  virtual void get_unsat_assumptions(UnorderedTermSet & out) = 0;
 
   /* Make an uninterpreted sort
    * SMTLIB: (declare-sort <name> <arity>)

--- a/include/utils.h
+++ b/include/utils.h
@@ -157,9 +157,9 @@ public:
 
   /** This clears the term translation cache. Note, term translator is used to
    *  translate the terms of the external solver to the
-   *  unsat-core-reducer-solver. A use-case of this method is to call it before
-   *  calling the reduce_assump_unsat from one call to another call when the
-   *  external solver in the first call is different from the second call.
+   *  unsat-assumption-reducer-solver. A use-case of this method is to call it
+   * before calling the reduce_assump_unsat from one call to another call when
+   * the external solver in the first call is different from the second call.
    */
   void clear_term_translation_cache() { to_reducer_.get_cache().clear(); };
 

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -78,7 +78,7 @@ class MsatSolver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(UnorderedTermSet & out) override;
+  void get_unsat_assumptions(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -145,7 +145,7 @@ void MsatSolver::set_opt(const string option, const string value)
                 << std::endl;
     }
   }
-  else if (option == "produce-unsat-cores")
+  else if (option == "produce-unsat-assumptions")
   {
     if (value == "false")
     {
@@ -359,7 +359,7 @@ UnorderedTermMap MsatSolver::get_array_values(const Term & arr,
   return assignments;
 }
 
-void MsatSolver::get_unsat_core(UnorderedTermSet & out)
+void MsatSolver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   size_t core_size;
   msat_term * mcore = msat_get_unsat_assumptions(env, &core_size);

--- a/python/smt_switch/smt_switch_dec.pxi
+++ b/python/smt_switch/smt_switch_dec.pxi
@@ -101,7 +101,7 @@ cdef extern from "solver.h" namespace "smt":
         void push(uint64_t num) except +
         void pop(uint64_t num) except +
         c_Term get_value(c_Term& t) except +
-        void get_unsat_core(c_UnorderedTermSet& out) except +
+        void get_unsat_assumptions(c_UnorderedTermSet& out) except +
         c_Sort make_sort(const string name, uint64_t arity) except +
         c_Sort make_sort(const c_SortKind sk) except +
         c_Sort make_sort(const c_SortKind sk, uint64_t size) except +

--- a/python/smt_switch/smt_switch_imp.pxi
+++ b/python/smt_switch/smt_switch_imp.pxi
@@ -283,15 +283,15 @@ cdef class SmtSolver:
         term.ct = dref(self.css).get_value(t.ct)
         return term
 
-    def get_unsat_core(self):
-        unsat_core = set()
+    def get_unsat_assumptions(self):
+        unsat_assumptions = set()
         cdef c_UnorderedTermSet cts
-        dref(self.css).get_unsat_core(cts)
+        dref(self.css).get_unsat_assumptions(cts)
         for l in cts:
             term = Term(self)
             term.ct = l
-            unsat_core.add(term)
-        return unsat_core
+            unsat_assumptions.add(term)
+        return unsat_assumptions
 
     def make_sort(self, arg0, arg1=None, arg2=None, arg3=None):
         cdef Sort s = Sort(self)

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -893,7 +893,7 @@ string GenericSolver::strip_value_from_result(string result) const
   return strip;
 }
 
-void GenericSolver::get_unsat_core(UnorderedTermSet & out)
+void GenericSolver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   // run get-unsat-assumptions command
   string result = run_command("(" + GET_UNSAT_ASSUMPTIONS_STR + ")", false);

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -469,10 +469,10 @@ Term LoggingSolver::get_value(const Term & t) const
   return res;
 }
 
-void LoggingSolver::get_unsat_core(UnorderedTermSet & out)
+void LoggingSolver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   UnorderedTermSet underlying_core;
-  wrapped_solver->get_unsat_core(underlying_core);
+  wrapped_solver->get_unsat_assumptions(underlying_core);
   for (auto c : underlying_core)
   {
     // assumption: these should be (possible negated) Boolean literals

--- a/src/printing_solver.cpp
+++ b/src/printing_solver.cpp
@@ -191,10 +191,10 @@ Term PrintingSolver::get_value(const Term & t) const
   return wrapped_solver->get_value(t);
 }
 
-void PrintingSolver::get_unsat_core(UnorderedTermSet & out)
+void PrintingSolver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   (*out_stream) << "(" << GET_UNSAT_ASSUMPTIONS_STR << ")" << endl;
-  wrapped_solver->get_unsat_core(out);
+  wrapped_solver->get_unsat_assumptions(out);
 }
 
 UnorderedTermMap PrintingSolver::get_array_values(const Term & arr,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -202,7 +202,7 @@ UnsatCoreReducer::UnsatCoreReducer(SmtSolver reducer_solver)
   : reducer_(reducer_solver),
     to_reducer_(reducer_solver)
 {
-  reducer_->set_opt("produce-unsat-cores", "true");
+  reducer_->set_opt("produce-unsat-assumptions", "true");
   reducer_->set_opt("incremental", "true");
 }
 
@@ -264,7 +264,7 @@ bool UnsatCoreReducer::reduce_assump_unsatcore(const Term &formula,
     local_assump.clear();
 
     UnorderedTermSet core_set;
-    reducer_->get_unsat_core(core_set);
+    reducer_->get_unsat_assumptions(core_set);
     for (const auto & a : cand_res) {
       Term l = label(a);
       if (core_set.find(l) != core_set.end()) {
@@ -361,7 +361,7 @@ bool UnsatCoreReducer::linear_reduce_assump_unsatcore(
       // of bool_assump[bool_assump_for_query] is because
       // the core could be even smaller
       UnorderedTermSet core_set;
-      reducer_->get_unsat_core(core_set);
+      reducer_->get_unsat_assumptions(core_set);
       { // remove those not in core_set from bool_assump
         TermVec new_bool_assump;
         new_bool_assump.reserve(core_set.size());

--- a/tests/cvc4/cvc4-printing.cpp
+++ b/tests/cvc4/cvc4-printing.cpp
@@ -133,7 +133,7 @@ void test1(SmtSolver s, ostream& os, stringbuf& strbuf) {
   Result r = s->check_sat_assuming(TermVec{ ind1 });
   assert(r.is_unsat());
   UnorderedTermSet usc;
-  s->get_unsat_core(usc);
+  s->get_unsat_assumptions(usc);
   s->pop(1);
   s->check_sat();
   s->get_value(x);

--- a/tests/python/test_unsat_core.py
+++ b/tests/python/test_unsat_core.py
@@ -18,15 +18,15 @@ import pytest
 import smt_switch as ss
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
-def test_unsat_core_simple(create_solver):
+def test_unsat_assumptions_simple(create_solver):
     solver = create_solver(False)
-    solver.set_opt("produce-unsat-cores", "true")
+    solver.set_opt("produce-unsat-assumptions", "true")
 
     boolsort = solver.make_sort(ss.sortkinds.BOOL)
     a = solver.make_symbol("a", boolsort)
     b = solver.make_symbol("b", boolsort)
     notB = solver.make_term(ss.primops.Not, b)
     r = solver.check_sat_assuming([a, b, notB]);
-    core = solver.get_unsat_core()
+    core = solver.get_unsat_assumptions()
     assert b in core, "expecting b to be in core"
     assert notB in core, "expecting (not b) to be in core"

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -563,7 +563,7 @@ void test_unsat_assumptions(SmtSolver gs)
   Result r = gs->check_sat_assuming(TermVec{ not_b1, b2, b3 });
   assert(r.is_unsat());
   UnorderedTermSet core;
-  gs->get_unsat_core(core);
+  gs->get_unsat_assumptions(core);
   std::cout << "core: " << std::endl;
   for (Term t : core)
   {

--- a/tests/test-unsat-core-reducer.cpp
+++ b/tests/test-unsat-core-reducer.cpp
@@ -1,5 +1,5 @@
 /*********************                                                        */
-/*! \file test-unsat-core-reducer.cpp
+/*! \file test-unsat-assumption-reducer.cpp
 ** \verbatim
 ** Top contributors (to current version):
 **   Ahmed Irfan, Makai Mann
@@ -9,7 +9,7 @@
 ** All rights reserved.  See the file LICENSE in the top-level source
 ** directory for licensing information.\endverbatim
 **
-** \brief Tests for unsat-core-based reducer.
+** \brief Tests for unsat-assumption-based reducer.
 **
 **
 **/

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -41,7 +41,7 @@ class UnsatCoreTests : public ::testing::Test,
     }
     else
     {
-      s->set_opt("produce-unsat-cores", "true");
+      s->set_opt("produce-unsat-assumptions", "true");
     }
     boolsort = s->make_sort(BOOL);
   }
@@ -62,7 +62,7 @@ TEST_P(UnsatCoreTests, UnsatCore)
   ASSERT_TRUE(r.is_unsat());
 
   UnorderedTermSet core;
-  s->get_unsat_core(core);
+  s->get_unsat_assumptions(core);
   ASSERT_TRUE(core.size() > 1);
 
   // for solvers using assumptions under the hood,
@@ -71,7 +71,7 @@ TEST_P(UnsatCoreTests, UnsatCore)
   ASSERT_TRUE(r.is_sat());
   // unsat core is only available after a call to check-sat-assuming, not
   // check-sat
-  ASSERT_THROW(s->get_unsat_core(core), SmtException);
+  ASSERT_THROW(s->get_unsat_assumptions(core), SmtException);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -70,7 +70,7 @@ class Yices2Solver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(UnorderedTermSet & out) override;
+  void get_unsat_assumptions(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -119,7 +119,7 @@ void Yices2Solver::set_opt(const std::string option, const std::string value)
       yices_set_config(config, "mode", "push-pop");
     }
   }
-  else if (option == "produce-unsat-cores")
+  else if (option == "produce-unsat-assumptions")
   {
     // nothing to be done
     ;
@@ -394,7 +394,7 @@ UnorderedTermMap Yices2Solver::get_array_values(const Term & arr,
       "particular select of the array.");
 }
 
-void Yices2Solver::get_unsat_core(UnorderedTermSet & out)
+void Yices2Solver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   term_vector_t ycore;
   yices_init_term_vector(&ycore);

--- a/z3/include/z3_solver.h
+++ b/z3/include/z3_solver.h
@@ -59,7 +59,7 @@ class Z3Solver : public AbsSmtSolver
   Term get_value(const Term & t) const override;
   UnorderedTermMap get_array_values(const Term & arr,
                                     Term & out_const_base) const override;
-  void get_unsat_core(UnorderedTermSet & out) override;
+  void get_unsat_assumptions(UnorderedTermSet & out) override;
   Sort make_sort(const std::string name, uint64_t arity) const override;
   Sort make_sort(SortKind sk) const override;
   Sort make_sort(SortKind sk, uint64_t size) const override;

--- a/z3/src/z3_solver.cpp
+++ b/z3/src/z3_solver.cpp
@@ -335,7 +335,7 @@ UnorderedTermMap Z3Solver::get_array_values(const Term & arr,
       "Get array values not implemented for Z3 backend.");
 }
 
-void Z3Solver::get_unsat_core(UnorderedTermSet & out)
+void Z3Solver::get_unsat_assumptions(UnorderedTermSet & out)
 {
   throw NotImplementedException(
       "Get unsat core not implemented for Z3 backend.");


### PR DESCRIPTION
`unsat-assumptions` is more accurate than `unsat-core`, because the smt-switch interface gives the core based on assumptions provided through `check-sat-assuming` and thus the command is actually analogous to `get-unsat-assumptions` rather than `get-unsat-core`.

This is an interface change that might affect users of smt-switch.