### PR TITLE
Add support for variadic operations

### DIFF
--- a/include/ops.h
+++ b/include/ops.h
@@ -179,3 +179,10 @@ namespace std
     };
 }
 
+namespace smt {
+// ops that can be applied to n arguments
+const std::unordered_set<PrimOp> variadic_ops(
+    { And, Or, Xor, Plus, BVAnd, BVOr, BVAdd });
+
+bool is_variadic(PrimOp po);
+}  // namespace smt

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -989,7 +989,27 @@ Term MsatSolver::make_term(Op op, const TermVec & terms) const
       }
       throw InternalSolverException(msg);
     }
-    return Term(new MsatTerm(env, res));
+    return make_shared<MsatTerm>(env, res);
+  }
+  else if (is_variadic(op.prim_op))
+  {
+    // assuming they are binary operators extended to n arguments
+    auto msat_fun = msat_binary_ops.at(op.prim_op);
+
+    // get msat_terms
+    vector<msat_term> margs;
+    margs.reserve(size);
+    for (const auto & tt : terms)
+    {
+      margs.push_back(static_pointer_cast<MsatTerm>(tt)->term);
+    }
+
+    msat_term res = msat_fun(env, margs[0], margs[1]);
+    for (size_t i = 2; i < size; ++i)
+    {
+      res = msat_fun(env, res, margs[i]);
+    }
+    return make_shared<MsatTerm>(env, res);
   }
   else
   {

--- a/src/ops.cpp
+++ b/src/ops.cpp
@@ -247,4 +247,9 @@ std::ostream & operator<<(std::ostream & output, const Op o)
   return output;
 }
 
+bool is_variadic(PrimOp po)
+{
+  return variadic_ops.find(po) != variadic_ops.end();
+}
+
 }  // namespace smt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -202,3 +202,8 @@ target_link_libraries(test-disjointset gtest_main)
 target_link_libraries(test-disjointset test-deps)
 add_test(NAME test-disjointset_test COMMAND test-disjointset)
 
+add_executable(test-variadic-ops "${PROJECT_SOURCE_DIR}/tests/test-variadic-ops.cpp")
+target_link_libraries(test-variadic-ops gtest_main)
+target_link_libraries(test-variadic-ops test-deps)
+add_test(NAME test-variadic-ops_test COMMAND test-variadic-ops)
+

--- a/tests/test-variadic-ops.cpp
+++ b/tests/test-variadic-ops.cpp
@@ -1,0 +1,72 @@
+/*********************                                                        */
+/*! \file test-variadic-ops.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Tests for applying n-ary operators
+**
+**
+**/
+
+#include <utility>
+#include <vector>
+
+#include "available_solvers.h"
+#include "gtest/gtest.h"
+#include "smt.h"
+
+using namespace smt;
+using namespace std;
+
+namespace smt_tests {
+
+class VariadicOpsTests
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<SolverConfiguration>
+{
+ protected:
+  void SetUp() override
+  {
+    s = create_solver(GetParam());
+    s->set_opt("produce-models", "true");
+    boolsort = s->make_sort(BOOL);
+  }
+  SmtSolver s;
+  Sort boolsort;
+};
+
+TEST_P(VariadicOpsTests, AND)
+{
+  size_t num_args = 20;
+  TermVec args;
+  args.reserve(num_args);
+
+  for (size_t i = 0; i < num_args; ++i)
+  {
+    args.push_back(s->make_symbol("b" + std::to_string(i), boolsort));
+  }
+
+  Term reduce_and = s->make_term(And, args);
+  s->assert_formula(reduce_and);
+  Result r = s->check_sat();
+  ASSERT_TRUE(r.is_sat());
+
+  Term term_true = s->make_term(true);
+
+  for (const auto & a : args)
+  {
+    EXPECT_EQ(s->get_value(a), term_true);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(ParameterizedSolverVariadicOpsTests,
+                         VariadicOpsTests,
+                         testing::ValuesIn(available_solver_configurations()));
+
+}  // namespace smt_tests


### PR DESCRIPTION
This PR adds support for variadic operations. For example, applying `And` to `n` terms. This was already supported through the CVC4 API, but other backends need to simulate it.