### PR TITLE
Return canonical objects for Python enums

### DIFF
--- a/python/smt_switch/enums_imp.pxi
+++ b/python/smt_switch/enums_imp.pxi
@@ -206,7 +206,7 @@ cdef class PrimOp:
         return (<int> self.po) != (<int> other.po)
 
     def __hash__(self):
-        return hash((<int> self.po, self.name))
+        return (<int> self.po)
 
     def __str__(self):
         return to_string(self.po).decode()
@@ -482,3 +482,17 @@ setattr(primops, 'Forall', Forall)
 cdef PrimOp Exists = PrimOp()
 Exists.po = c_Exists
 setattr(primops, 'Exists', Exists)
+
+##################################### dictionaries for getting canonical enum objects ###################
+
+int2primop = dict()
+for attr in dir(primops):
+    if not attr.startswith("_"):
+        pypo = getattr(primops, attr)
+        int2primop[(<int> (<PrimOp?> pypo).po)] = pypo
+
+int2sortkind = dict()
+for attr in dir(sortkinds):
+    if not attr.startswith("_"):
+        pysk = getattr(sortkinds, attr)
+        int2sortkind[(<int> (<SortKind?> pysk).sk)] = pysk

--- a/python/smt_switch/smt_switch_imp.pxi
+++ b/python/smt_switch/smt_switch_imp.pxi
@@ -17,6 +17,7 @@ from smt_switch cimport c_PrimOp, c_SortKind, c_BOOL
 from smt_switch cimport get_free_symbolic_consts as c_get_free_symbolic_consts
 from smt_switch cimport get_free_symbols as c_get_free_symbols
 
+
 cdef class Op:
     def __cinit__(self, prim_op=None, idx0=None, idx1=None):
         if isinstance(prim_op, PrimOp):
@@ -31,9 +32,8 @@ cdef class Op:
 
     @property
     def prim_op(self):
-        cdef PrimOp po = PrimOp()
-        po.po = self.op.prim_op
-        return po
+        # look up the canonical object
+        return int2primop[(<int> self.op.prim_op)]
 
     @property
     def num_idx(self):
@@ -138,9 +138,8 @@ cdef class Sort:
         return s
 
     def get_sort_kind(self):
-        cdef SortKind sk = SortKind()
-        sk.sk = dref(self.cs).get_sort_kind()
-        return sk
+        # look up canonical SortKind object
+        return int2sortkind[(<int> dref(self.cs).get_sort_kind())]
 
     def __eq__(self, Sort other):
         return self.cs == other.cs

--- a/tests/python/test_enums.py
+++ b/tests/python/test_enums.py
@@ -1,0 +1,42 @@
+###############################################################
+# \file test_enums.py
+# \verbatim
+# Top contributors (to current version):
+#   Makai Mann
+# This file is part of the smt-switch project.
+# Copyright (c) 2020 by the authors listed in the file AUTHORS
+# in the top-level source directory) and their institutional affiliations.
+# All rights reserved.  See the file LICENSE in the top-level source
+# directory for licensing information.\endverbatim
+#
+# \brief Test getters for enums (SortKind and PrimOp)
+#
+#
+
+import pytest
+import smt_switch as ss
+
+
+@pytest.mark.parametrize("create_solver", [f for name, f in ss.solvers.items() if name != 'btor'])
+def test_sortkind(create_solver):
+    solver = ss.create_cvc4_solver(False)
+    bvsort = solver.make_sort(ss.sortkinds.BV, 8)
+    x = solver.make_symbol("x", bvsort)
+    sk = x.get_sort().get_sort_kind()
+    assert hash(ss.sortkinds.BV) == hash(sk)
+    assert sk == ss.sortkinds.BV
+    assert sk is ss.sortkinds.BV
+
+
+@pytest.mark.parametrize("create_solver", [f for name, f in ss.solvers.items() if name != 'btor'])
+def test_primop(create_solver):
+    solver = ss.create_cvc4_solver(False)
+    bvsort = solver.make_sort(ss.sortkinds.BV, 8)
+    x = solver.make_symbol("x", bvsort)
+    y = solver.make_symbol("y", bvsort)
+    xpy = solver.make_term(ss.primops.BVAdd, x, y)
+    op = xpy.get_op()
+
+    assert hash(ss.primops.BVAdd) == hash(op.prim_op)
+    assert op.prim_op == ss.primops.BVAdd
+    assert op.prim_op is ss.primops.BVAdd

--- a/tests/python/test_enums.py
+++ b/tests/python/test_enums.py
@@ -19,7 +19,7 @@ import smt_switch as ss
 
 @pytest.mark.parametrize("create_solver", [f for name, f in ss.solvers.items() if name != 'btor'])
 def test_sortkind(create_solver):
-    solver = ss.create_cvc4_solver(False)
+    solver = create_solver(False)
     bvsort = solver.make_sort(ss.sortkinds.BV, 8)
     x = solver.make_symbol("x", bvsort)
     sk = x.get_sort().get_sort_kind()
@@ -30,7 +30,7 @@ def test_sortkind(create_solver):
 
 @pytest.mark.parametrize("create_solver", [f for name, f in ss.solvers.items() if name != 'btor'])
 def test_primop(create_solver):
-    solver = ss.create_cvc4_solver(False)
+    solver = create_solver(False)
     bvsort = solver.make_sort(ss.sortkinds.BV, 8)
     x = solver.make_symbol("x", bvsort)
     y = solver.make_symbol("y", bvsort)


### PR DESCRIPTION
This PR adds a dictionary to look up the canonical object for both `SortKind`s and `PrimOp`. This ensures that the object returned by `sort.get_sort_kind()` or `op.prim_op` is identical to the one used to create sorts and terms, respectively. This also guarantees that the `hash` works as intended.