### PR TITLE
Support set-opt and set-logic in msat backend

### DIFF
--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -41,13 +41,18 @@ namespace smt {
 class MsatSolver : public AbsSmtSolver
 {
  public:
-  // constructor does basically nothing
-  // but in mathsat factory, MUST setup_env
-  // this is done after constructing because need to call
-  // the virtual function -- e.g. simulating dynamic binding
-  MsatSolver() : AbsSmtSolver(MSAT), logic(""){};
+  MsatSolver()
+    : AbsSmtSolver(MSAT),
+      cfg(msat_create_config()),
+      env_uninitialized(true),
+      logic(""){};
   MsatSolver(msat_config c, msat_env e)
-      : AbsSmtSolver(MSAT), cfg(c), env(e), valid_model("false"), logic(""){};
+      : AbsSmtSolver(MSAT),
+        cfg(c),
+        env(e),
+        env_uninitialized(false),
+        valid_model(false),
+        logic(""){};
   MsatSolver(const MsatSolver &) = delete;
   MsatSolver & operator=(const MsatSolver &) = delete;
   ~MsatSolver()
@@ -56,15 +61,11 @@ class MsatSolver : public AbsSmtSolver
     // a program that just creates a msat_env leaks
     //  -- be careful, valgrind won't report leaks on statically compiled
     //  binaries
-    msat_destroy_env(env);
+    if (!env_uninitialized)
+    {
+      msat_destroy_env(env);
+    }
     msat_destroy_config(cfg);
-  }
-  virtual void setup_env()
-  {
-    cfg = msat_create_config();
-    msat_set_option(cfg, "model_generation", "true");
-    env = msat_create_env(cfg);
-    valid_model = false;
   }
   void set_opt(const std::string option, const std::string value) override;
   void set_logic(const std::string log) override;
@@ -134,11 +135,26 @@ class MsatSolver : public AbsSmtSolver
 
  protected:
   msat_config cfg;
-  msat_env env;
+  // marked mutable because want to stick with const interface for functions
+  // but the environment cannot be created before setting options
+  // it will be lazily created when first used (which might be in a const function)
+  mutable msat_env env;
+  mutable bool env_uninitialized;
   bool valid_model;
   std::string logic;
 
   // helper function for creating labels for assumptions
+
+  // initializes the env (if not already done)
+  virtual void initialize_env() const
+  {
+    if (env_uninitialized)
+    {
+      env = msat_create_env(cfg);
+      env_uninitialized = false;
+    }
+  }
+
   msat_term label(msat_term p) const;
 
   inline Result check_sat_assuming(std::vector<msat_term> & m_assumps)
@@ -175,17 +191,6 @@ class MsatInterpolatingSolver : public MsatSolver
   MsatInterpolatingSolver(const MsatInterpolatingSolver &) = delete;
   MsatInterpolatingSolver & operator=(const MsatInterpolatingSolver &) = delete;
   ~MsatInterpolatingSolver() {}
-  virtual void setup_env() override
-  {
-    cfg = msat_create_config();
-    msat_set_option(cfg, "theory.bv.eager", "false");
-    msat_set_option(cfg, "theory.bv.bit_blast_mode", "0");
-    msat_set_option(cfg, "interpolation", "true");
-    // TODO: decide if we should add this
-    // msat_set_option(cfg, "theory.eq_propagation", "false");
-    env = msat_create_env(cfg);
-    valid_model = false;
-  }
   void set_opt(const std::string option, const std::string value) override;
   void assert_formula(const Term & t) override;
   Result check_sat() override;
@@ -196,6 +201,21 @@ class MsatInterpolatingSolver : public MsatSolver
                          Term & out_I) const override;
   Result get_sequence_interpolants(const TermVec & formulae,
                                    TermVec & out_I) const override;
+
+ protected:
+  virtual void initialize_env() const override
+  {
+    if (env_uninitialized)
+    {
+      msat_set_option(cfg, "theory.bv.eager", "false");
+      msat_set_option(cfg, "theory.bv.bit_blast_mode", "0");
+      msat_set_option(cfg, "interpolation", "true");
+      // TODO: decide if we should add this
+      // msat_set_option(cfg, "theory.eq_propagation", "false");
+      env = msat_create_env(cfg);
+      env_uninitialized = false;
+    }
+  }
 };
 
 }  // namespace smt

--- a/msat/src/msat_factory.cpp
+++ b/msat/src/msat_factory.cpp
@@ -26,7 +26,6 @@ namespace smt {
 SmtSolver MsatSolverFactory::create(bool logging)
 {
   MsatSolver * ms = new MsatSolver();
-  ms->setup_env();
   SmtSolver solver(ms);
   if (logging)
   {
@@ -38,7 +37,6 @@ SmtSolver MsatSolverFactory::create(bool logging)
 SmtSolver MsatSolverFactory::create_interpolating_solver()
 {
   MsatInterpolatingSolver * mis = new MsatInterpolatingSolver();
-  mis->setup_env();
   std::shared_ptr<MsatInterpolatingSolver> s(mis);
   return s;
 }


### PR DESCRIPTION
This PR adds support for set-opt and set-logic in the msat backend. The MathSAT API requires setting all the options before creating the environment. To accommodate this, the env is lazily initialized when it is needed. Prior to that, options and the logic can be set on the `msat_config` object.

It's worth considering requiring the logic and options up front when creating a solver in the future. The current implementation is more like smt-lib but might make less sense in the API. At least MathSAT and Z3 have the same limitation regarding setting options.