### PR TITLE
Check sat assuming msat

### DIFF
--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -137,6 +137,11 @@ class MsatSolver : public AbsSmtSolver
   // for interacting with third-party MathSAT-specific software
   msat_env get_msat_env() const { return env; };
 
+  // getters and setters for advanced use / testing
+  size_t max_assump_clauses() const { return max_assump_clauses_; }
+
+  void set_max_assump_clauses(size_t m) { max_assump_clauses_ = m; }
+
  protected:
   msat_config cfg;
   // marked mutable because want to stick with const interface for functions

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -204,6 +204,7 @@ class MsatSolver : public AbsSmtSolver
       // check that label is cached correctly
       assert(msat_term_id(lbl) == msat_term_id(label(ma)));
       msat_assert_formula(env, msat_make_or(env, msat_make_not(env, lbl), ma));
+      num_assump_clauses_++;
       assumption_map_[msat_term_id(lbl)] = ma;
       lbls.push_back(lbl);
     }

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -58,7 +58,9 @@ class MsatSolver : public AbsSmtSolver
         valid_model(false),
         logic(""),
         num_assump_clauses_(0),
-        max_assump_clauses_(10000){};
+        max_assump_clauses_(10000)
+    {
+    };
   MsatSolver(const MsatSolver &) = delete;
   MsatSolver & operator=(const MsatSolver &) = delete;
   ~MsatSolver()

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -167,6 +167,8 @@ class MsatSolver : public AbsSmtSolver
     for (const auto & ma : m_assumps)
     {
       lbl = label(ma);
+      // check that label is cached correctly
+      assert(msat_term_id(lbl) == msat_term_id(label(ma)));
       msat_assert_formula(env, msat_make_or(env, msat_make_not(env, lbl), ma));
       assumption_map_[msat_term_id(lbl)] = ma;
       lbls.push_back(lbl);

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -47,7 +47,9 @@ class MsatSolver : public AbsSmtSolver
         env_uninitialized(true),
         logic(""),
         num_assump_clauses_(0),
-        max_assump_clauses_(10000){};
+        max_assump_clauses_(10000)
+    {
+    };
   MsatSolver(msat_config c, msat_env e)
       : AbsSmtSolver(MSAT),
         cfg(c),
@@ -276,4 +278,3 @@ class MsatInterpolatingSolver : public MsatSolver
 };
 
 }  // namespace smt
-

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -142,6 +142,7 @@ class MsatSolver : public AbsSmtSolver
   mutable bool env_uninitialized;
   bool valid_model;
   std::string logic;
+  std::unordered_map<size_t, msat_term> assumption_map_;
 
   // helper function for creating labels for assumptions
 

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -201,7 +201,7 @@ class MsatSolver : public AbsSmtSolver
   // helper function for creating labels for assumptions
   msat_term label(msat_term p) const;
 
-  inline Result check_sat_assuming(std::vector<msat_term> & m_assumps)
+  inline Result check_sat_assuming_msatvec(std::vector<msat_term> & m_assumps)
   {
     msat_term lbl;
     assumption_map_.clear();

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -160,8 +160,22 @@ class MsatSolver : public AbsSmtSolver
 
   inline Result check_sat_assuming(std::vector<msat_term> & m_assumps)
   {
+    msat_term lbl;
+    assumption_map_.clear();
+    std::vector<msat_term> lbls;
+    lbls.reserve(m_assumps.size());
+    for (const auto & ma : m_assumps)
+    {
+      lbl = label(ma);
+      msat_assert_formula(env, msat_make_or(env, msat_make_not(env, lbl), ma));
+      assumption_map_[msat_term_id(lbl)] = ma;
+      lbls.push_back(lbl);
+    }
+
+    assert(lbls.size() == m_assumps.size());
+
     msat_result mres =
-        msat_solve_with_assumptions(env, &m_assumps[0], m_assumps.size());
+        msat_solve_with_assumptions(env, lbls.data(), lbls.size());
 
     if (mres == MSAT_SAT)
     {

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -1169,6 +1169,8 @@ msat_term MsatSolver::label(msat_term p) const
   std::string name = buf.str();
   msat_decl d =
       msat_declare_function(env, name.c_str(), msat_get_bool_type(env));
+  // if it already existed, mathsat gives the same symbol
+  // in this case, those semantics are perfect -- we don't need a cache
   return msat_make_constant(env, d);
 }
 

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -1097,6 +1097,7 @@ void MsatSolver::reset_assertions()
 {
   initialize_env();
   msat_reset_env(env);
+  base_assertions_.clear();
 }
 
 Term MsatSolver::substitute(const Term term,

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -181,11 +181,18 @@ void MsatSolver::assert_formula(const Term & t)
     msg += t->to_string();
     throw IncorrectUsageException(msg);
   }
+
+  if (!msat_num_backtrack_points(env))
+  {
+    // keep track of base-level assertions
+    base_assertions_.push_back(mterm->term);
+  }
 }
 
 Result MsatSolver::check_sat()
 {
   initialize_env();
+  clear_assumption_clauses();
   msat_result mres = msat_solve(env);
 
   if (mres == MSAT_SAT)
@@ -205,7 +212,7 @@ Result MsatSolver::check_sat()
 Result MsatSolver::check_sat_assuming(const TermVec & assumptions)
 {
   initialize_env();
-
+  clear_assumption_clauses();
   size_t num_assumps = assumptions.size();
   vector<msat_term> m_assumps;
   m_assumps.reserve(num_assumps);
@@ -223,6 +230,7 @@ Result MsatSolver::check_sat_assuming(const TermVec & assumptions)
 Result MsatSolver::check_sat_assuming_list(const TermList & assumptions)
 {
   initialize_env();
+  clear_assumption_clauses();
   // expecting (possibly negated) boolean literals
   for (const auto & a : assumptions)
   {
@@ -256,6 +264,7 @@ Result MsatSolver::check_sat_assuming_list(const TermList & assumptions)
 Result MsatSolver::check_sat_assuming_set(const UnorderedTermSet & assumptions)
 {
   initialize_env();
+  clear_assumption_clauses();
   // expecting (possibly negated) boolean literals
   for (const auto & a : assumptions)
   {

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -1156,6 +1156,14 @@ void MsatSolver::dump_smt2(std::string filename) const
 msat_term MsatSolver::label(msat_term p) const
 {
   initialize_env();
+
+  if (msat_term_is_boolean_constant(env, p) ||
+      (msat_term_is_not(env, p) && msat_term_is_boolean_constant(env, msat_term_get_arg(p, 0))))
+  {
+    // if a (negated) boolean constant, don't need a fresh label
+    return p;
+  }
+
   std::ostringstream buf;
   buf << ".assump_lbl{" << msat_term_id(p) << "}";
   std::string name = buf.str();

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -224,7 +224,7 @@ Result MsatSolver::check_sat_assuming(const TermVec & assumptions)
     m_assumps.push_back(ma);
   }
 
-  return check_sat_assuming(m_assumps);
+  return check_sat_assuming_msatvec(m_assumps);
 }
 
 Result MsatSolver::check_sat_assuming_list(const TermList & assumptions)
@@ -258,7 +258,7 @@ Result MsatSolver::check_sat_assuming_list(const TermList & assumptions)
     m_assumps.push_back(ma->term);
   }
 
-  return check_sat_assuming(m_assumps);
+  return check_sat_assuming_msatvec(m_assumps);
 }
 
 Result MsatSolver::check_sat_assuming_set(const UnorderedTermSet & assumptions)
@@ -292,7 +292,7 @@ Result MsatSolver::check_sat_assuming_set(const UnorderedTermSet & assumptions)
     m_assumps.push_back(ma->term);
   }
 
-  return check_sat_assuming(m_assumps);
+  return check_sat_assuming_msatvec(m_assumps);
 }
 
 void MsatSolver::push(uint64_t num)

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -210,18 +210,11 @@ Result MsatSolver::check_sat_assuming(const TermVec & assumptions)
   vector<msat_term> m_assumps;
   m_assumps.reserve(num_assumps);
 
-  msat_term ma, lbl;
-  assumption_map_.clear();
+  msat_term ma;
   for (size_t i = 0; i < num_assumps; ++i)
   {
     ma = static_pointer_cast<MsatTerm>(assumptions[i])->term;
-    lbl = label(ma);
-    msat_assert_formula(env,
-                        msat_make_or(env,
-                                     msat_make_not(env, lbl),
-                                     ma));
-    m_assumps.push_back(lbl);
-    assumption_map_[msat_term_id(lbl)] = ma;
+    m_assumps.push_back(ma);
   }
 
   return check_sat_assuming(m_assumps);

--- a/tests/msat/msat-incremental.cpp
+++ b/tests/msat/msat-incremental.cpp
@@ -17,13 +17,11 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
+#include "msat_solver.h"  // only needed for the static_pointer_cast for testing
 #include "smt.h"
-// after full installation
-// #include "smt-switch/cvc4_factory.h"
-// #include "smt-switch/smt.h"
 
 using namespace smt;
 using namespace std;
@@ -34,6 +32,11 @@ int main()
   s->set_logic("QF_BV");
   s->set_opt("produce-models", "true");
   s->set_opt("incremental", "true");
+
+  // test with clearing assumption clauses every
+  // check-sat/check-sat-assuming call
+  // NOTE this is only for testing / advanced usage
+  static_pointer_cast<MsatSolver>(s)->set_max_assump_clauses(0);
 
   Sort bvsort8 = s->make_sort(BV, 8);
   Term x = s->make_symbol("x", bvsort8);

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -44,9 +44,10 @@ class UnsatCoreTests : public ::testing::Test,
       s->set_opt("produce-unsat-assumptions", "true");
     }
     boolsort = s->make_sort(BOOL);
+    bvsort = s->make_sort(BV, 8);
   }
   SmtSolver s;
-  Sort boolsort;
+  Sort boolsort, bvsort;
 };
 
 // FIXME there's some issue with the Yices2 context object which
@@ -72,6 +73,23 @@ TEST_P(UnsatCoreTests, UnsatCore)
   // unsat core is only available after a call to check-sat-assuming, not
   // check-sat
   ASSERT_THROW(s->get_unsat_assumptions(core), SmtException);
+}
+
+TEST_P(UnsatCoreTests, UnsatCoreNonLit)
+{
+  // test that everything works in a fresh context
+  Term x = s->make_symbol("x", bvsort);
+  Term y = s->make_symbol("y", bvsort);
+
+  Term x_lt_y = s->make_term(BVUlt, x, y);
+  Term x_ge_y = s->make_term(BVUge, x, y);
+
+  Result r = s->check_sat_assuming({ x_lt_y, x_ge_y });
+  ASSERT_TRUE(r.is_unsat());
+
+  UnorderedTermSet core;
+  s->get_unsat_assumptions(core);
+  ASSERT_TRUE(core.size() > 1);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -87,6 +87,12 @@ TEST_P(UnsatCoreTests, UnsatCoreNonLit)
   Result r = s->check_sat_assuming({ x_lt_y, x_ge_y });
   ASSERT_TRUE(r.is_unsat());
 
+  r = s->check_sat_assuming({x_lt_y});
+  ASSERT_TRUE(r.is_sat());
+
+  r = s->check_sat_assuming({x_lt_y, x_ge_y});
+  ASSERT_TRUE(r.is_unsat());
+
   UnorderedTermSet core;
   s->get_unsat_assumptions(core);
   ASSERT_TRUE(core.size() > 1);


### PR DESCRIPTION
This PR would support arbitrary formulas in check-sat-assuming in the mathsat backend. The motivation for this is that most other solvers allow this and there's a good argument that it is consistent with the SMT-LIB standard. SMT-LIB requires that the arguments to check-sat-assuming be symbols. But those symbols could be from a `define-fun` which might make that symbol an alias for an arbitrary term. Thus in the text interface, it is basically just requiring that the assumption has a _name_. Through the API we are using the objects directly and thus it makes sense to be able to use any arbitrary term.

This PR simulates the more general interface by creating labels as needed. To avoid polluting the global assertions with lots of labels, it periodically resets the environment (if at context 0). This also requires keeping track of "actual" assertions and re-adding them after resetting. I set the number of clauses to consider worth clearing to 10,000.