### PR TITLE
Use a pointer to a vector for lists of s-exprs in parser

### DIFF
--- a/src/smtlibparser.yy
+++ b/src/smtlibparser.yy
@@ -91,7 +91,7 @@ US "_"
 %nterm command
 %nterm smt2
 %nterm <smt::Term> s_expr
-%nterm <smt::TermVec> s_expr_list
+%nterm <smt::TermVec *> s_expr_list
 %nterm <smt::Term> atom
 %nterm <smt::Term> bvconst
 %nterm <smt::Sort> sort
@@ -178,7 +178,8 @@ command:
   }
   | LP CHECKSATASSUMING LP s_expr_list RP RP
   {
-    drv.check_sat_assuming($4);
+    drv.check_sat_assuming(*$4);
+    delete $4;
   }
   | LP PUSH RP
   {
@@ -212,14 +213,15 @@ s_expr:
     // special-case for MINUS
     // needs to be negate if only one argument
     // TODO: might be a more elegant way to handle this
-    if ($2 == smt::Minus && $3.size() == 1)
+    if ($2 == smt::Minus && $3->size() == 1)
     {
-      $$ = drv.solver()->make_term(smt::Negate, $3[0]);
+      $$ = drv.solver()->make_term(smt::Negate, $3->at(0));
     }
     else
     {
-      $$ = drv.solver()->make_term($2, $3);
+      $$ = drv.solver()->make_term($2, *$3);
     }
+    delete $3;
   }
   | LP SYMBOL s_expr_list RP
   {
@@ -228,14 +230,15 @@ s_expr:
     if (uf)
     {
       smt::TermVec vec({uf});
-      vec.insert(vec.end(), $3.begin(), $3.end());
+      vec.insert(vec.end(), $3->begin(), $3->end());
       $$ = drv.solver()->make_term(smt::Apply, vec);
     }
     else
     {
       // assuming this is a defined fun
-      $$ = drv.apply_define_fun($2, $3);
+      $$ = drv.apply_define_fun($2, *$3);
     }
+    delete $3;
   }
   | LP LP ASCONST sort RP atom RP
   {
@@ -272,14 +275,12 @@ s_expr:
 s_expr_list:
    %empty
    {
-     smt::TermVec vec;
-     $$ = vec;
+     $$ = new smt::TermVec();
    }
    | s_expr_list s_expr
    {
-     smt::TermVec & vec = $1;
-     vec.push_back($2);
-     $$ = vec;
+     $1->push_back($2);
+     $$ = $1;
    }
 ;
 


### PR DESCRIPTION
This PR would use a pointer to a vector for representing a list of sexprs. This is to avoid copying the vector. For some reason, marking the semantic value as a reference does not seem to work.