### PR TITLE
Workaround for push in trivial unsat status in Yices2 backend

### DIFF
--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -40,7 +40,7 @@ namespace smt {
 class Yices2Solver : public AbsSmtSolver
 {
  public:
-  Yices2Solver() : AbsSmtSolver(YICES2)
+  Yices2Solver() : AbsSmtSolver(YICES2), pushes_after_unsat(0)
   {
     // Had to move yices_init to the Factory
     // yices_init();
@@ -121,6 +121,10 @@ class Yices2Solver : public AbsSmtSolver
  protected:
   mutable context_t * ctx;
   mutable ctx_config_t * config;
+
+  // workaround for: https://github.com/makaimann/smt-switch/issues/218
+  size_t pushes_after_unsat;  ///< how many pushes after trivial unsat context
+                              ///< status
 
   // helper function
   inline Result check_sat_assuming(const std::vector<term_t> & y_assumps)

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -367,9 +367,32 @@ Result Yices2Solver::check_sat_assuming_set(
   return check_sat_assuming(y_assumps);
 }
 
-void Yices2Solver::push(uint64_t num) { yices_push(ctx); }
+void Yices2Solver::push(uint64_t num)
+{
+  if (yices_context_status(ctx) == STATUS_UNSAT)
+  {
+    pushes_after_unsat += num;
+    return;
+  }
 
-void Yices2Solver::pop(uint64_t num) { yices_pop(ctx); }
+  for (size_t i = 0; i < num; ++i)
+  {
+    yices_push(ctx);
+  }
+}
+
+void Yices2Solver::pop(uint64_t num)
+{
+  for (size_t i = 0; i < num; ++i)
+  {
+    if (pushes_after_unsat)
+    {
+      pushes_after_unsat--;
+      continue;
+    }
+    yices_pop(ctx);
+  }
+}
 
 Term Yices2Solver::get_value(const Term & t) const
 {


### PR DESCRIPTION
Fixes https://github.com/makaimann/smt-switch/issues/218. See https://github.com/SRI-CSL/yices2/issues/358 for workaround suggestion.