### PR TITLE
Add a contribution policy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,5 +7,10 @@ The core designers and authors of smt-switch are:
 
   Makai Mann, Stanford University
   Amalee Wilson, Stanford University
+  Yoni Zohar, Stanford University
+  Lindsey Stuntz, Stanford University
   Cesare Tinelli, The University of Iowa
   Clark Barrett, Stanford University
+
+Alumni:
+  Ahmed Irfan, Stanford University

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+External contributions to smt-switch may be proposed via a pull request. All
+external contributions are subject to the following terms:
+* Pull requests must be squashed into a single commit before being submitted and
+  must be signed using `git commit -s`
+* By submitting a signed contribution, you agree to all the terms of the
+  3-clause BSD license (see [./LICENSE])
+* But submitting a signed contribution, you agree that the [Developer
+  Certificate of Origin](https://developercertificate.org/) (reproduced below)
+  applies to your contribution.
+  
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ external contributions are subject to the following terms:
 * Pull requests must be squashed into a single commit before being submitted and
   must be signed using `git commit -s`
 * By submitting a signed contribution, you agree to all the terms of the
-  3-clause BSD license (see [./LICENSE])
+  3-clause BSD license (see [LICENSE](./LICENSE))
 * But submitting a signed contribution, you agree that the [Developer
   Certificate of Origin](https://developercertificate.org/) (reproduced below)
   applies to your contribution.

--- a/README.md
+++ b/README.md
@@ -161,3 +161,10 @@ A `LoggingSolver` is a wrapper around another `SmtSolver` that keeps track of Te
 * Yices2
   * Use a `LoggingSolver` if you need term iteration
   * Yices2 has a different term representation under the hood which cannot easily be converted back to SMT-LIB. Thus, term traversal is currently only supported through a `LoggingSolver`.
+
+## Contributions
+
+We welcome external contributions, please see
+[CONTRIBUTING.md](./CONTRIBUTING.md) for more details. If you are interested in
+becoming a long-term contributor to smt-switch, please contact one of the
+primary authors in [AUTHORS](./AUTHORS)

--- a/THANKS
+++ b/THANKS
@@ -1,0 +1,23 @@
+Thanks to:
+
+* Keyi Zhang of Stanford University for adding the Python wheels distribution
+  and PyPi upload infrastructure.
+
+* Hongce Zhang of Princeton University for the addition of an unsat core
+  reduction function.
+
+* Bart van Helvert of JetBrains for an improvement to the handling of the
+  distinct operator in the Yices2 backend.
+
+* Andrew V. Jones of VECTOR Informatik for a clarification in the README
+  regarding BSD compliant underlying solvers.
+
+* Kristopher Brown of Stanford University for adding Datatypes support to the
+  CVC4 backend.
+
+* Allison Guman of Columbia University for adding a TreeWalker.
+
+* Thomas Kiley for a code quality improvement.
+
+* Caleb Donovick of Stanford University for adding a PySMT translation module
+  and improvements to the Python bindings setup.py infrastructure.


### PR DESCRIPTION
This PR would add an external contribution policy and adds a THANKS file, both based on those used in [cvc5](https://github.com/cvc5/cvc5).