### PR TITLE
Use prefix 'smtlib' for lexer to avoid yy* redefinitions

### DIFF
--- a/include/smtlib_reader.h
+++ b/include/smtlib_reader.h
@@ -23,7 +23,7 @@
 #include "smt.h"
 #include "smtlibparser.h"
 
-#define YY_DECL yy::parser::symbol_type yylex(smt::SmtLibReader & drv)
+#define YY_DECL smtlib::parser::symbol_type yylex(smt::SmtLibReader & drv)
 YY_DECL;
 
 namespace smt {
@@ -151,7 +151,7 @@ class SmtLibReader
   virtual void pop(uint64_t num = 1);
 
   /* getters and setters  */
-  yy::location & location() { return location_; }
+  smtlib::location & location() { return location_; }
 
   smt::SmtSolver & solver() { return solver_; }
 
@@ -267,7 +267,7 @@ class SmtLibReader
   void let_binding(const std::string & sym, const smt::Term & term);
 
  protected:
-  yy::location location_;
+  smtlib::location location_;
 
   smt::SmtSolver solver_;
 

--- a/src/smtlib_reader.cpp
+++ b/src/smtlib_reader.cpp
@@ -79,7 +79,7 @@ int SmtLibReader::parse(const std::string & f)
   int res;
   try
   {
-    yy::parser parse(*this);
+    smtlib::parser parse(*this);
     // commented from calc++ example
     // parse.set_debug_level (trace_parsing);
     res = parse();

--- a/src/smtlibparser.yy
+++ b/src/smtlibparser.yy
@@ -28,6 +28,8 @@ using namespace std;
 %define api.token.constructor
 %define api.value.type variant
 
+%define api.prefix {smtlib}
+
 %code requires {
 /*********************                                                        */
 /*! \file smtlibparser.[yy/h]
@@ -321,7 +323,7 @@ atom:
       if (!sym)
       {
         // Note: using @1 will force locations to be enabled
-        yy::parser::error(@1, std::string("Unrecognized symbol: ") + $1);
+        smtlib::parser::error(@1, std::string("Unrecognized symbol: ") + $1);
         YYERROR;
       }
       $$ = sym;
@@ -384,7 +386,7 @@ sort:
      if (sk == smt::NUM_SORT_KINDS)
      {
        // got dedicated null enum
-       yy::parser::error(@2, std::string("Unrecognized sort: ") + $2);
+       smtlib::parser::error(@2, std::string("Unrecognized sort: ") + $2);
        YYERROR;
      }
      $$ = drv.solver()->make_sort(sk, std::stoi($3));
@@ -463,7 +465,7 @@ indexed_op:
      smt::PrimOp po = drv.lookup_primop($2);
      if (po == smt::NUM_OPS_AND_NULL)
      {
-       yy::parser::error(@2, "Unexpected symbol in indexed operator: " + $2);
+       smtlib::parser::error(@2, "Unexpected symbol in indexed operator: " + $2);
      }
      $$ = smt::Op(po, std::stoi($3));
    }
@@ -472,7 +474,7 @@ indexed_op:
      smt::PrimOp po = drv.lookup_primop($2);
      if (po == smt::NUM_OPS_AND_NULL)
      {
-       yy::parser::error(@2, "Unexpected symbol in indexed operator: " + $2);
+       smtlib::parser::error(@2, "Unexpected symbol in indexed operator: " + $2);
      }
      $$ = smt::Op(po, std::stoi($3), std::stoi($4));
    }
@@ -523,7 +525,7 @@ indprefix:
 
 %%
 
-void yy::parser::error (const location_type& l, const std::string& m)
+void smtlib::parser::error (const location_type& l, const std::string& m)
 {
   cerr << l << ": " << m << endl;
 }

--- a/src/smtlibscanner.l
+++ b/src/smtlibscanner.l
@@ -22,6 +22,7 @@ using namespace std;
 %}
 
 %option noyywrap nounput noinput batch
+%option prefix="smtlib"
 /* can uncomment next line to give debug output during lexing */
 /* %option debug */
 
@@ -36,7 +37,7 @@ symbol [a-zA-Z~!@\$%\^&\*+=<>\.\?/_-][a-zA-Z0-9~!@\$%\^&\*+=<>\.\?/_-]*
 
 %{
   // A handy shortcut to the location held by the driver.
-  yy::location& loc = drv.location();
+  smtlib::location& loc = drv.location();
   // Code run each time yylex is called.
   loc.step ();
 %}
@@ -45,27 +46,27 @@ symbol [a-zA-Z~!@\$%\^&\*+=<>\.\?/_-][a-zA-Z0-9~!@\$%\^&\*+=<>\.\?/_-]*
 
 \;.*                  ;/* skip comment */
 
-\(                    { return yy::parser::make_LP(loc); }
-\)                    { return yy::parser::make_RP(loc); }
-_                     { return yy::parser::make_US(loc); }
+\(                    { return smtlib::parser::make_LP(loc); }
+\)                    { return smtlib::parser::make_RP(loc); }
+_                     { return smtlib::parser::make_US(loc); }
 
-set-logic             { return yy::parser::make_SETLOGIC(loc); }
-set-option            { return yy::parser::make_SETOPT(loc); }
-set-info              { return yy::parser::make_SETINFO(loc); }
-declare-const         { return yy::parser::make_DECLARECONST(loc); }
-declare-fun           { return yy::parser::make_DECLAREFUN(loc); }
-declare-sort          { return yy::parser::make_DECLARESORT(loc); }
-define-fun            { return yy::parser::make_DEFINEFUN(loc); }
-define-sort           { return yy::parser::make_DEFINESORT(loc); }
-assert                { return yy::parser::make_ASSERT(loc); }
-check-sat             { return yy::parser::make_CHECKSAT(loc); }
-check-sat-assuming    { return yy::parser::make_CHECKSATASSUMING(loc); }
-push                  { return yy::parser::make_PUSH(loc); }
-pop                   { return yy::parser::make_POP(loc); }
-exit                  { return yy::parser::make_EXIT(loc); }
-get-value[ \t\r]*     { return yy::parser::make_GETVALUE(loc); }
-get-unsat-assumptions { return yy::parser::make_GETUNSATASSUMP(loc); }
-echo                  { return yy::parser::make_ECHO(loc); }
+set-logic             { return smtlib::parser::make_SETLOGIC(loc); }
+set-option            { return smtlib::parser::make_SETOPT(loc); }
+set-info              { return smtlib::parser::make_SETINFO(loc); }
+declare-const         { return smtlib::parser::make_DECLARECONST(loc); }
+declare-fun           { return smtlib::parser::make_DECLAREFUN(loc); }
+declare-sort          { return smtlib::parser::make_DECLARESORT(loc); }
+define-fun            { return smtlib::parser::make_DEFINEFUN(loc); }
+define-sort           { return smtlib::parser::make_DEFINESORT(loc); }
+assert                { return smtlib::parser::make_ASSERT(loc); }
+check-sat             { return smtlib::parser::make_CHECKSAT(loc); }
+check-sat-assuming    { return smtlib::parser::make_CHECKSATASSUMING(loc); }
+push                  { return smtlib::parser::make_PUSH(loc); }
+pop                   { return smtlib::parser::make_POP(loc); }
+exit                  { return smtlib::parser::make_EXIT(loc); }
+get-value[ \t\r]*     { return smtlib::parser::make_GETVALUE(loc); }
+get-unsat-assumptions { return smtlib::parser::make_GETUNSATASSUMP(loc); }
+echo                  { return smtlib::parser::make_ECHO(loc); }
 
 \"(\\.|[^\"\\])*\"    { char * noquotes = yytext;
                         noquotes++;
@@ -79,20 +80,20 @@ echo                  { return yy::parser::make_ECHO(loc); }
                           }
                         }
                         loc.step();
-                        return yy::parser::make_QUOTESTRING(noquotes, loc);
+                        return smtlib::parser::make_QUOTESTRING(noquotes, loc);
                       }
 
-[0-9]+                { return yy::parser::make_NAT(yytext, loc); }
-[0-9]+\.[0-9]+        { return yy::parser::make_FLOAT(yytext, loc); }
-#b[01]+               { yytext=yytext+2; return yy::parser::make_BITSTR(yytext, loc); }
-#x[0-9a-fA-F]+        { yytext=yytext+2; return yy::parser::make_HEXSTR(yytext, loc); }
-bv[0-9]+              { yytext=yytext+2; return yy::parser::make_BVDEC(yytext, loc); }
-as[ \t\r\n]+const     { return yy::parser::make_ASCONST(loc); }
-let                   { return yy::parser::make_LET(loc); }
+[0-9]+                { return smtlib::parser::make_NAT(yytext, loc); }
+[0-9]+\.[0-9]+        { return smtlib::parser::make_FLOAT(yytext, loc); }
+#b[01]+               { yytext=yytext+2; return smtlib::parser::make_BITSTR(yytext, loc); }
+#x[0-9a-fA-F]+        { yytext=yytext+2; return smtlib::parser::make_HEXSTR(yytext, loc); }
+bv[0-9]+              { yytext=yytext+2; return smtlib::parser::make_BVDEC(yytext, loc); }
+as[ \t\r\n]+const     { return smtlib::parser::make_ASCONST(loc); }
+let                   { return smtlib::parser::make_LET(loc); }
 
-\:[a-zA-Z0-9_-]+      { return yy::parser::make_KEYWORD(++yytext, loc); }
+\:[a-zA-Z0-9_-]+      { return smtlib::parser::make_KEYWORD(++yytext, loc); }
 
-(forall|exists)       { return yy::parser::make_QUANTIFIER(yytext, loc); }
+(forall|exists)       { return smtlib::parser::make_QUANTIFIER(yytext, loc); }
 
 \|([^|\\])*\|         {
                         // increment location for each line
@@ -107,12 +108,12 @@ let                   { return yy::parser::make_LET(loc); }
                         // get rid of pipe quotes
                         yytext++;
                         yytext[strlen(yytext)-1] = '\0';
-                        return yy::parser::make_SYMBOL(yytext, loc);
+                        return smtlib::parser::make_SYMBOL(yytext, loc);
                       }
-{symbol}              { return yy::parser::make_SYMBOL(yytext, loc); }
+{symbol}              { return smtlib::parser::make_SYMBOL(yytext, loc); }
 
 .                     { throw SmtException(std::string("Parser ERROR on: ") + yytext); }
-<<EOF>>               { return yy::parser::make_YYEOF (loc); }
+<<EOF>>               { return smtlib::parser::make_SMTLIBEOF (loc); }
 %%
 
 void smt::SmtLibReader::scan_begin ()


### PR DESCRIPTION
Use a dedicated prefix, `smtlib`, so that there aren't re-definitions of the `yy*` functions when there are other flex lexers.