### PR TITLE
Add symbol table to solver backends

### DIFF
--- a/bitwuzla/include/bitwuzla_solver.h
+++ b/bitwuzla/include/bitwuzla_solver.h
@@ -45,7 +45,12 @@ class BzlaSolver : public AbsSmtSolver
   };
   BzlaSolver(const BzlaSolver &) = delete;
   BzlaSolver & operator=(const BzlaSolver &) = delete;
-  ~BzlaSolver() { bitwuzla_delete(bzla); };
+  ~BzlaSolver()
+  {
+    // need to destruct all stored terms in symbol_table
+    symbol_table.clear();
+    bitwuzla_delete(bzla);
+  };
   void set_opt(const std::string option, const std::string value) override;
   void set_logic(const std::string logic) override;
   void assert_formula(const Term & t) override;
@@ -122,6 +127,8 @@ class BzlaSolver : public AbsSmtSolver
 
  protected:
   Bitwuzla * bzla;
+
+  std::unordered_map<std::string, Term> symbol_table;
 
   // helper functions
   template <class I>

--- a/bitwuzla/include/bitwuzla_solver.h
+++ b/bitwuzla/include/bitwuzla_solver.h
@@ -102,6 +102,7 @@ class BzlaSolver : public AbsSmtSolver
                  uint64_t base = 10) const override;
   Term make_term(const Term & val, const Sort & sort) const override;
   Term make_symbol(const std::string name, const Sort & sort) override;
+  Term get_symbol(const std::string & name) override;
   Term make_param(const std::string name, const Sort & sort) override;
   /* build a new term */
   Term make_term(Op op, const Term & t) const override;

--- a/bitwuzla/src/bitwuzla_solver.cpp
+++ b/bitwuzla/src/bitwuzla_solver.cpp
@@ -459,6 +459,16 @@ Term BzlaSolver::make_symbol(const string name, const Sort & sort)
   return sym;
 }
 
+Term BzlaSolver::get_symbol(const string & name)
+{
+  auto it = symbol_table.find(name);
+  if (it == symbol_table.end())
+  {
+    throw IncorrectUsageException("Symbol named " + name + " does not exist.");
+  }
+  return it->second;
+}
+
 Term BzlaSolver::make_param(const std::string name, const Sort & sort)
 {
   shared_ptr<BzlaSort> bsort = static_pointer_cast<BzlaSort>(sort);

--- a/bitwuzla/src/bitwuzla_solver.cpp
+++ b/bitwuzla/src/bitwuzla_solver.cpp
@@ -448,9 +448,15 @@ Term BzlaSolver::make_term(const Term & val, const Sort & sort) const
 
 Term BzlaSolver::make_symbol(const string name, const Sort & sort)
 {
+  if (symbol_table.find(name) != symbol_table.end())
+  {
+    throw IncorrectUsageException("Symbol name " + name + " already used.");
+  }
   shared_ptr<BzlaSort> bsort = static_pointer_cast<BzlaSort>(sort);
-  return make_shared<BzlaTerm>(
-      bitwuzla_mk_const(bzla, bsort->sort, name.c_str()));
+  Term sym =
+      make_shared<BzlaTerm>(bitwuzla_mk_const(bzla, bsort->sort, name.c_str()));
+  symbol_table[name] = sym;
+  return sym;
 }
 
 Term BzlaSolver::make_param(const std::string name, const Sort & sort)

--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -99,6 +99,7 @@ class BoolectorSolver : public AbsSmtSolver
                  uint64_t base = 10) const override;
   Term make_term(const Term & val, const Sort & sort) const override;
   Term make_symbol(const std::string name, const Sort & sort) override;
+  Term get_symbol(const std::string & name) override;
   Term make_param(const std::string name, const Sort & sort) override;
   /* build a new term */
   Term make_term(Op op, const Term & t) const override;

--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -50,6 +50,8 @@ class BoolectorSolver : public AbsSmtSolver
   BoolectorSolver & operator=(const BoolectorSolver &) = delete;
   ~BoolectorSolver()
   {
+    // need to destruct all stored terms in the symbol_table
+    symbol_table.clear();
     boolector_delete(btor);
   };
   void set_opt(const std::string option, const std::string value) override;
@@ -124,8 +126,8 @@ class BoolectorSolver : public AbsSmtSolver
 
  protected:
   Btor * btor;
-  // store the names of created symbols
-  std::unordered_set<std::string> symbol_names;
+
+  std::unordered_map<std::string, Term> symbol_table;
 
   bool base_context_1 = false;
   ///< if set to true, do all solving at context 1 in the solver

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -654,6 +654,16 @@ Term BoolectorSolver::make_symbol(const std::string name, const Sort & sort)
   return term;
 }
 
+Term BoolectorSolver::get_symbol(const std::string & name)
+{
+  auto it = symbol_table.find(name);
+  if (it == symbol_table.end())
+  {
+    throw IncorrectUsageException("Symbol named " + name + " does not exist.");
+  }
+  return it->second;
+}
+
 Term BoolectorSolver::make_param(const std::string name, const Sort & sort)
 {
   std::shared_ptr<BoolectorSortBase> bs =

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -625,7 +625,7 @@ Term BoolectorSolver::make_symbol(const std::string name, const Sort & sort)
 {
   // check that name is available
   // avoids memory leak when boolector aborts
-  if (symbol_names.find(name) != symbol_names.end())
+  if (symbol_table.find(name) != symbol_table.end())
   {
     throw IncorrectUsageException("symbol " + name + " has already been used.");
   }
@@ -650,7 +650,7 @@ Term BoolectorSolver::make_symbol(const std::string name, const Sort & sort)
 
   // note: giving the symbol a null Op
   Term term = std::make_shared<BoolectorTerm> (btor, n);
-  symbol_names.insert(name);
+  symbol_table[name] = term;
   return term;
 }
 

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -97,6 +97,7 @@ class CVC4Solver : public AbsSmtSolver
                  uint64_t base = 10) const override;
   Term make_term(const Term & val, const Sort & sort) const override;
   Term make_symbol(const std::string name, const Sort & sort) override;
+  Term get_symbol(const std::string & name) override;
   Term make_param(const std::string name, const Sort & sort) override;
   /* build a new term */
   Term make_term(Op op, const Term & t) const override;

--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -121,8 +121,8 @@ class CVC4Solver : public AbsSmtSolver
 
  protected:
   ::CVC4::api::Solver solver;
-  // keep track of created symbols
-  std::unordered_map<std::string, Term> symbols;
+
+  std::unordered_map<std::string, Term> symbol_table;
 
   // helper function
   inline Result check_sat_assuming(

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -658,6 +658,16 @@ Term CVC4Solver::make_symbol(const std::string name, const Sort & sort)
   }
 }
 
+Term CVC4Solver::get_symbol(const std::string & name)
+{
+  auto it = symbol_table.find(name);
+  if (it == symbol_table.end())
+  {
+    throw IncorrectUsageException("Symbol named " + name + " does not exist.");
+  }
+  return it->second;
+}
+
 Term CVC4Solver::make_param(const std::string name, const Sort & sort)
 {
   try

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -638,9 +638,10 @@ Term CVC4Solver::make_symbol(const std::string name, const Sort & sort)
 {
   // check that name is available
   // to make CVC4 behave the same as other solvers
-  if (symbols.find(name) != symbols.end())
+  if (symbol_table.find(name) != symbol_table.end())
   {
-    throw IncorrectUsageException("symbol " + name + " has already been used.");
+    throw IncorrectUsageException("Symbol name " + name
+                                  + " has already been used.");
   }
 
   try
@@ -648,7 +649,7 @@ Term CVC4Solver::make_symbol(const std::string name, const Sort & sort)
     std::shared_ptr<CVC4Sort> csort = std::static_pointer_cast<CVC4Sort>(sort);
     ::CVC4::api::Term t = solver.mkConst(csort->sort, name);
     Term res = std::make_shared<::smt::CVC4Term> (t);
-    symbols[name] = res;
+    symbol_table[name] = res;
     return res;
   }
   catch (::CVC4::api::CVC4ApiException & e)

--- a/include/generic_solver.h
+++ b/include/generic_solver.h
@@ -90,6 +90,7 @@ class GenericSolver : public AbsSmtSolver
                  uint64_t base = 10) const override;
   Term make_term(const Term & val, const Sort & sort) const override;
   Term make_symbol(const std::string name, const Sort & sort) override;
+  Term get_symbol(const std::string & name) override;
   Term make_param(const std::string name, const Sort & sort) override;
   Term make_term(const Op op, const Term & t) const override;
   Term make_term(const Op op, const Term & t0, const Term & t1) const override;
@@ -242,14 +243,14 @@ class GenericSolver : public AbsSmtSolver
   uint write_buf_size;
   uint read_buf_size;
 
-  // maps between sort name and actual sort and vice verse
+  // maps between sort name and actual sort and vice versa
   std::unique_ptr<std::unordered_map<std::string, Sort>> name_sort_map;
   std::unique_ptr<std::unordered_map<Sort, std::string>> sort_name_map;
 
   // internal counter for naming terms
   uint * term_counter;
 
-  // maps between sort name and actual sort and vice verse
+  // maps between Term name and actual Term and vice versa
   std::unique_ptr<std::unordered_map<std::string, Term>> name_term_map;
   std::unique_ptr<std::unordered_map<Term, std::string>> term_name_map;
 

--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -62,6 +62,7 @@ class LoggingSolver : public AbsSmtSolver
                  uint64_t base = 10) const override;
   Term make_term(const Term & val, const Sort & sort) const override;
   Term make_symbol(const std::string name, const Sort & sort) override;
+  Term get_symbol(const std::string & name) override;
   Term make_param(const std::string name, const Sort & sort) override;
   Term make_term(const Op op, const Term & t) const override;
   Term make_term(const Op op, const Term & t0, const Term & t1) const override;
@@ -93,6 +94,7 @@ class LoggingSolver : public AbsSmtSolver
  protected:
   SmtSolver wrapped_solver;  ///< the underlying solver
   std::unique_ptr<TermHashTable> hashtable;
+
   // stores a mapping from wrapped terms to logging terms
   // that were used in check_sat_assuming
   // this is so they can be recovered with the correct children/op

--- a/include/logging_solver.h
+++ b/include/logging_solver.h
@@ -95,6 +95,8 @@ class LoggingSolver : public AbsSmtSolver
   SmtSolver wrapped_solver;  ///< the underlying solver
   std::unique_ptr<TermHashTable> hashtable;
 
+  std::unordered_map<std::string, Term> symbol_table;
+
   // stores a mapping from wrapped terms to logging terms
   // that were used in check_sat_assuming
   // this is so they can be recovered with the correct children/op

--- a/include/printing_solver.h
+++ b/include/printing_solver.h
@@ -70,6 +70,7 @@ class PrintingSolver : public AbsSmtSolver
    * For example, creating terms is not printed, but the
    * created terms will appear in other commands (e.g., assert). 
    * */
+  Term get_symbol(const std::string & name) override;
   Sort make_sort(const SortKind sk) const override;
   Sort make_sort(const SortKind sk, uint64_t size) const override;
   Sort make_sort(const SortKind sk, const Sort & sort1) const override;

--- a/include/solver.h
+++ b/include/solver.h
@@ -231,7 +231,17 @@ class AbsSmtSolver
 
   /** Look up a symbol by name.
    *  If no symbol of that name has been declared, throws
-   * IncorrectUsageException
+   *  IncorrectUsageException
+   *
+   *  Allows a user to look up a symbol by name. This can be very useful for term
+   *  translation, since we can look up symbols instead of keeping track of the
+   *  mapping via externally populated caches (in the case where the target
+   *  solver has already been used).
+   *
+   *  Note, solver backend deals with the implementation. The main motivation for
+   *  this is that each backend solver has to own the symbol table. If the symbol
+   *  table were stored in AbsSmtSolver then it would get destructed after the
+   *  backend solver which has bad refcounting implications for many solvers.
    *
    *  @param name the name of the symbol to look up
    *  @return the Term representation of the corresponding symbol

--- a/include/solver.h
+++ b/include/solver.h
@@ -229,6 +229,15 @@ class AbsSmtSolver
    */
   virtual Term make_symbol(const std::string name, const Sort & sort) = 0;
 
+  /** Look up a symbol by name.
+   *  If no symbol of that name has been declared, throws
+   * IncorrectUsageException
+   *
+   *  @param name the name of the symbol to look up
+   *  @return the Term representation of the corresponding symbol
+   */
+  virtual Term get_symbol(const std::string & name) = 0;
+
   /* Make a parameter term to be bound by a quantifier
    * @param name the name of the parameter
    * @param sort the sort of this parameter

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -121,6 +121,7 @@ class MsatSolver : public AbsSmtSolver
                  uint64_t base = 10) const override;
   Term make_term(const Term & val, const Sort & sort) const override;
   Term make_symbol(const std::string name, const Sort & sort) override;
+  Term get_symbol(const std::string & name) override;
   Term make_param(const std::string name, const Sort & sort) override;
   /* build a new term */
   Term make_term(Op op, const Term & t) const override;

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -713,9 +713,9 @@ Term MsatSolver::make_symbol(const string name, const Sort & sort)
   if (!MSAT_ERROR_DECL(decl))
   {
     // symbol already exists
-    string msg("Symbol ");
+    string msg("Symbol name ");
     msg += name;
-    msg += " already exists.";
+    msg += " has already used.";
     throw IncorrectUsageException(msg);
   }
 

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -752,6 +752,27 @@ Term MsatSolver::make_symbol(const string name, const Sort & sort)
   }
 }
 
+Term MsatSolver::get_symbol(const std::string & name)
+{
+  msat_decl decl = msat_find_decl(env, name.c_str());
+  if (MSAT_ERROR_DECL(decl))
+  {
+    // symbol already exists
+    string msg("Symbol named ");
+    msg += name;
+    msg += " does not exist.";
+    throw IncorrectUsageException(msg);
+  }
+
+  msat_term res = msat_make_constant(env, decl);
+  if (MSAT_ERROR_TERM(res))
+  {
+    // assume it is a function
+    return std::make_shared<MsatTerm>(env, decl);
+  }
+  return std::make_shared<MsatTerm>(env, res);
+}
+
 Term MsatSolver::make_param(const std::string name, const Sort & sort)
 {
   initialize_env();

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -1084,8 +1084,15 @@ UnorderedTermSet GenericSolver::get_assumptions_from_string(string result) const
 
     // retrieve the literal from the map
     string str_atom = strip.substr(begin, end - begin + 1);
-    assert(name_term_map->find(str_atom) != name_term_map->end());
-    Term atom = (*name_term_map)[str_atom];
+    auto it = name_term_map->find(str_atom);
+    if (it == name_term_map->end())
+    {
+      // solvers don't always print with the pipes
+      // need to add those back in
+      it = name_term_map->find("|" + str_atom + "|");
+      assert(it != name_term_map->end());
+    }
+    Term atom = it->second;
     Term literal;
     if (positive)
     {

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -841,6 +841,16 @@ Term GenericSolver::make_symbol(const string name, const Sort & sort)
   return (*name_term_map)[name];
 }
 
+Term GenericSolver::get_symbol(const string & name)
+{
+  auto it = name_term_map->find(name);
+  if (it == name_term_map->end())
+  {
+    throw IncorrectUsageException("Symbol named " + name + " does not exist.");
+  }
+  return it->second;
+}
+
 Term GenericSolver::make_param(const string name, const Sort & sort)
 {
   if (name_term_map->find(name) != name_term_map->end())

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -276,15 +276,19 @@ Term LoggingSolver::make_symbol(const string name, const Sort & sort)
     next_term_id++;
   }
 
+  symbol_table[name] = res;
+
   return res;
 }
 
-Term LoggingSolver::get_symbol(const string & name)
+Term LoggingSolver::get_symbol(const std::string & name)
 {
-  Term res = wrapped_solver->get_symbol(name);
-  bool success = hashtable->lookup(res);
-  assert(success);
-  return res;
+  auto it = symbol_table.find(name);
+  if (it == symbol_table.end())
+  {
+    throw IncorrectUsageException("Symbol named " + name + " does not exist.");
+  }
+  return it->second;
 }
 
 Term LoggingSolver::make_param(const string name, const Sort & sort)

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -279,6 +279,14 @@ Term LoggingSolver::make_symbol(const string name, const Sort & sort)
   return res;
 }
 
+Term LoggingSolver::get_symbol(const string & name)
+{
+  Term res = wrapped_solver->get_symbol(name);
+  bool success = hashtable->lookup(res);
+  assert(success);
+  return res;
+}
+
 Term LoggingSolver::make_param(const string name, const Sort & sort)
 {
   shared_ptr<LoggingSort> lsort = static_pointer_cast<LoggingSort>(sort);

--- a/src/printing_solver.cpp
+++ b/src/printing_solver.cpp
@@ -34,6 +34,11 @@ PrintingSolver::PrintingSolver(SmtSolver s, std::ostream* os, PrintingStyleEnum 
 
 PrintingSolver::~PrintingSolver() {}
 
+Term PrintingSolver::get_symbol(const string & name)
+{
+  return wrapped_solver->get_symbol(name);
+}
+
 Sort PrintingSolver::make_sort(const string name, uint64_t arity) const
 {
   (*out_stream) << "(" << DECLARE_SORT_STR << " " << name << " " << arity << ")" << endl;

--- a/tests/test-term-translation.cpp
+++ b/tests/test-term-translation.cpp
@@ -178,9 +178,6 @@ TEST_P(TranslationTests, And)
   TermTranslator to_s2(s2);
 
   TermTranslator to_s1(s1);
-  UnorderedTermMap & cache = to_s1.get_cache();
-  cache[to_s2.transfer_term(a)] = a;
-  cache[to_s2.transfer_term(b)] = b;
 
   Term a_and_b_2 = to_s2.transfer_term(a_and_b);
   Term a_and_b_1 = to_s1.transfer_term(a_and_b_2);
@@ -193,9 +190,6 @@ TEST_P(TranslationTests, Equal)
   TermTranslator to_s2(s2);
 
   TermTranslator to_s1(s1);
-  UnorderedTermMap & cache = to_s1.get_cache();
-  cache[to_s2.transfer_term(a)] = a;
-  cache[to_s2.transfer_term(b)] = b;
 
   Term a_equal_b_2 = to_s2.transfer_term(a_equal_b);
   // need to specify expected sortkind
@@ -218,10 +212,6 @@ TEST_P(TranslationTests, Ite)
 
   TermTranslator to_s2(s2);
   TermTranslator to_s1(s1);
-  UnorderedTermMap & cache = to_s1.get_cache();
-  cache[to_s2.transfer_term(a)] = a;
-  cache[to_s2.transfer_term(x)] = x;
-  cache[to_s2.transfer_term(y)] = y;
 
   Term a_ite_x_y_2 = to_s2.transfer_term(a_ite_x_y);
   Term a_ite_x_y_1 = to_s1.transfer_term(a_ite_x_y_2);
@@ -239,9 +229,6 @@ TEST_P(TranslationTests, Concat)
 
   TermTranslator to_s2(s2);
   TermTranslator to_s1(s1);
-  UnorderedTermMap & cache = to_s1.get_cache();
-  cache[to_s2.transfer_term(x)] = x;
-  cache[to_s2.transfer_term(y)] = y;
 
   Term concat_term_2 = to_s2.transfer_term(concat_term);
   Term concat_term_1 = to_s1.transfer_term(concat_term_2);
@@ -258,8 +245,6 @@ TEST_P(TranslationTests, Extract)
 
   TermTranslator to_s2(s2);
   TermTranslator to_s1(s1);
-  UnorderedTermMap & cache = to_s1.get_cache();
-  cache[to_s2.transfer_term(a)] = a;
 
   Term ext_bv_a_2 = to_s2.transfer_term(ext_bv_a);
   // expect it to be a BV
@@ -302,11 +287,6 @@ TEST_P(TranslationTests, UninterpretedSort)
   Term fv_2 = to_s2.transfer_term(fv);
   EXPECT_EQ(fv_2->get_op(), Apply);
 
-  // populate cache with symbols for back translation
-  UnorderedTermMap & cache = to_s1.get_cache();
-  cache[to_s2.transfer_term(v)] = v;
-  cache[to_s2.transfer_term(f)] = f;
-
   Term fv_1 = to_s1.transfer_term(fv_2);
   EXPECT_EQ(fv, fv_1);
 }
@@ -321,10 +301,6 @@ TEST_P(BoolArrayTranslationTests, Arrays)
 
   TermTranslator to_s2(s2);
   TermTranslator to_s1(s1);
-  UnorderedTermMap & cache = to_s1.get_cache();
-  cache[to_s2.transfer_term(arr)] = arr;
-  cache[to_s2.transfer_term(x)] = x;
-  cache[to_s2.transfer_term(y)] = y;
 
   Term stores_2 = to_s2.transfer_term(stores);
   Term stores_1 = to_s1.transfer_term(stores_2);

--- a/tests/unit/unit-symbol.cpp
+++ b/tests/unit/unit-symbol.cpp
@@ -75,6 +75,8 @@ TEST_P(UnitSymbolTests, GetSymbol)
 
   EXPECT_EQ(funky_sym, s->get_symbol(funky_name));
   EXPECT_EQ(funky_sym_fun, s->get_symbol(funky_name_fun));
+
+  EXPECT_THROW(s->get_symbol("nonexistent_symbol"), IncorrectUsageException);
 }
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnitSymbol,

--- a/tests/unit/unit-symbol.cpp
+++ b/tests/unit/unit-symbol.cpp
@@ -56,6 +56,19 @@ TEST_P(UnitSymbolTests, RedeclareException)
   EXPECT_THROW(s->make_symbol("a", arrsort), IncorrectUsageException);
 }
 
+TEST_P(UnitSymbolTests, GetSymbol)
+{
+  Term b = s->make_symbol("b", boolsort);
+  Term x = s->make_symbol("x", bvsort);
+  Term f = s->make_symbol("f", funsort);
+  Term a = s->make_symbol("a", arrsort);
+
+  EXPECT_EQ(b, s->get_symbol("b"));
+  EXPECT_EQ(x, s->get_symbol("x"));
+  EXPECT_EQ(f, s->get_symbol("f"));
+  EXPECT_EQ(a, s->get_symbol("a"));
+}
+
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnitSymbol,
                          UnitSymbolTests,
                          testing::ValuesIn(available_solver_configurations()));

--- a/tests/unit/unit-symbol.cpp
+++ b/tests/unit/unit-symbol.cpp
@@ -67,6 +67,14 @@ TEST_P(UnitSymbolTests, GetSymbol)
   EXPECT_EQ(x, s->get_symbol("x"));
   EXPECT_EQ(f, s->get_symbol("f"));
   EXPECT_EQ(a, s->get_symbol("a"));
+
+  string funky_name = "strange @ name!";
+  string funky_name_fun = "strange Fun _ name$";
+  Term funky_sym = s->make_symbol(funky_name, boolsort);
+  Term funky_sym_fun = s->make_symbol(funky_name_fun, funsort);
+
+  EXPECT_EQ(funky_sym, s->get_symbol(funky_name));
+  EXPECT_EQ(funky_sym_fun, s->get_symbol(funky_name_fun));
 }
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverUnitSymbol,

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -106,6 +106,7 @@ class Yices2Solver : public AbsSmtSolver
                  uint64_t base = 10) const override;
   Term make_term(const Term & val, const Sort & sort) const override;
   Term make_symbol(const std::string name, const Sort & sort) override;
+  Term get_symbol(const std::string & name) override;
   Term make_param(const std::string name, const Sort & sort) override;
   /* build a new term */
   Term make_term(Op op, const Term & t) const override;

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -51,6 +51,9 @@ class Yices2Solver : public AbsSmtSolver
   Yices2Solver & operator=(const Yices2Solver &) = delete;
   ~Yices2Solver()
   {
+    // need to destruct all stored terms in symbol_table
+    symbol_table.clear();
+
     yices_free_config(config);
     yices_free_context(ctx);
 
@@ -126,7 +129,7 @@ class Yices2Solver : public AbsSmtSolver
   size_t pushes_after_unsat;  ///< how many pushes after trivial unsat context
                               ///< status
 
-  std::unordered_set<std::string> symbols;
+  std::unordered_map<std::string, Term> symbol_table;
   ///< Keep track of declared symbols to avoid re-declaration
   ///< Note: Yices2 has a global symbol table, but we want it
   ///< associated with each solver instance. This is why we

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -645,22 +645,27 @@ Sort Yices2Solver::make_sort(const Sort & sort_con, const SortVec & sorts) const
 
 Term Yices2Solver::make_symbol(const std::string name, const Sort & sort)
 {
-  if (symbols.find(name) != symbols.end())
+  if (symbol_table.find(name) != symbol_table.end())
   {
     throw IncorrectUsageException("symbol " + name + " has already been used.");
   }
-  symbols.insert(name);
 
   shared_ptr<Yices2Sort> ysort = static_pointer_cast<Yices2Sort>(sort);
   term_t y_term = yices_new_uninterpreted_term(ysort->type);
   yices_set_term_name(y_term, name.c_str());
 
+  Term sym;
   if (ysort->get_sort_kind() == FUNCTION)
   {
-    return std::make_shared<Yices2Term> (y_term, true);
+    sym = std::make_shared<Yices2Term>(y_term, true);
   }
-
-  return std::make_shared<Yices2Term> (y_term);
+  else
+  {
+    sym = std::make_shared<Yices2Term>(y_term);
+  }
+  assert(sym);
+  symbol_table[name] = sym;
+  return sym;
 }
 
 Term Yices2Solver::make_param(const std::string name, const Sort & sort)

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -668,6 +668,16 @@ Term Yices2Solver::make_symbol(const std::string name, const Sort & sort)
   return sym;
 }
 
+Term Yices2Solver::get_symbol(const std::string & name)
+{
+  auto it = symbol_table.find(name);
+  if (it == symbol_table.end())
+  {
+    throw IncorrectUsageException("Symbol named " + name + " does not exist.");
+  }
+  return it->second;
+}
+
 Term Yices2Solver::make_param(const std::string name, const Sort & sort)
 {
   throw NotImplementedException("make_param not supported by Yices2 yet.");

--- a/z3/include/z3_solver.h
+++ b/z3/include/z3_solver.h
@@ -120,7 +120,7 @@ class Z3Solver : public AbsSmtSolver
  protected:
   mutable z3::context ctx;
   mutable z3::solver slv;
-  std::unordered_set<std::string> symbols;
+  std::unordered_map<std::string, Term> symbol_table;
   ///< keep track of declared symbols to avoid
   ///< re-declaring
 

--- a/z3/include/z3_solver.h
+++ b/z3/include/z3_solver.h
@@ -98,6 +98,7 @@ class Z3Solver : public AbsSmtSolver
                  uint64_t base = 10) const override;
   Term make_term(const Term & val, const Sort & sort) const override;
   Term make_symbol(const std::string name, const Sort & sort) override;
+  Term get_symbol(const std::string & name) override;
   Term make_param(const std::string name, const Sort & sort) override;
   /* build a new term */
   Term make_term(Op op, const Term & t) const override;

--- a/z3/src/z3_solver.cpp
+++ b/z3/src/z3_solver.cpp
@@ -645,6 +645,16 @@ Term Z3Solver::make_symbol(const std::string name, const Sort & sort)
   return sym;
 }
 
+Term Z3Solver::get_symbol(const std::string & name)
+{
+  auto it = symbol_table.find(name);
+  if (it == symbol_table.end())
+  {
+    throw IncorrectUsageException("Symbol named " + name + " does not exist.");
+  }
+  return it->second;
+}
+
 Term Z3Solver::make_param(const std::string name, const Sort & sort)
 {
   shared_ptr<Z3Sort> zsort = static_pointer_cast<Z3Sort>(sort);

--- a/z3/src/z3_solver.cpp
+++ b/z3/src/z3_solver.cpp
@@ -609,16 +609,16 @@ Sort Z3Solver::make_sort(const Sort & sort_con, const SortVec & sorts) const
 
 Term Z3Solver::make_symbol(const std::string name, const Sort & sort)
 {
-  if (symbols.find(name) != symbols.end())
+  if (symbol_table.find(name) != symbol_table.end())
   {
     throw IncorrectUsageException("symbol " + name + " has already been used.");
   }
-  symbols.insert(name);
 
   shared_ptr<Z3Sort> zsort = static_pointer_cast<Z3Sort>(sort);
   const char * c = name.c_str();
   z3::symbol z_name = ctx.str_symbol(c);
 
+  Term sym;
   if (zsort->get_sort_kind() == FUNCTION)
   {
     // nb this is creating a func_decl
@@ -631,15 +631,18 @@ Term Z3Solver::make_symbol(const std::string name, const Sort & sort)
     }
 
     func_decl z_func = ctx.function(c, domain, sort_func.range());
-    return std::make_shared<Z3Term>(z_func, ctx);
+    sym = std::make_shared<Z3Term>(z_func, ctx);
   }
   else
   {
     // nb this is creating an expr
     expr z_term = ctx.constant(z_name, zsort->type);
 
-    return std::make_shared<Z3Term>(z_term, ctx);
+    sym = std::make_shared<Z3Term>(z_term, ctx);
   }
+  assert(sym);
+  symbol_table[name] = sym;
+  return sym;
 }
 
 Term Z3Solver::make_param(const std::string name, const Sort & sort)


### PR DESCRIPTION
This PR adds a `get_symbol` feature to `AbsSmtSolver`. This allows a user to look up a symbol by name. This can be very useful for term translation as well, so we can look up symbols instead of keeping track of the mapping via externally populated caches (in the case where the target solver has already been used).

Note, this implementation lets each solver backend deal with how to implement `get_symbol`. It results in some code duplication, but I think it's the easiest to understand. Especially because each backend solver has to own the symbol table. If the symbol table were stored in `AbsSmtSolver` then it would get destructed _after_ the backend solver which has bad refcounting implications for many solvers.