### PR TITLE
Update cvc5 to 1.3.4

### DIFF
--- a/contrib/setup-cvc5.sh
+++ b/contrib/setup-cvc5.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-git_tag=cvc5-1.3.3
+git_tag=cvc5-1.3.4
 cmake_options=(-DENABLE_AUTO_DOWNLOAD=ON -DUSE_POLY=ON)
 
 prepare_step() {


### PR DESCRIPTION
Fixes a libpoly compilation error on macOS.